### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/src/mcp-stdio-client.test.ts
+++ b/src/mcp-stdio-client.test.ts
@@ -109,10 +109,7 @@ describe.skipIf(!hasTestDb && !dbWasExplicitlyConfigured)(
     });
 
     const transportErrors: Error[] = [];
-    let resolveClosed: () => void = () => {};
-    const closeSeen = new Promise<void>((resolve) => {
-      resolveClosed = resolve;
-    });
+    const { promise: closeSeen, resolve: resolveClosed } = Promise.withResolvers<void>();
     let closeCount = 0;
 
     client = new Client({ name: "stdio-test-client", version: "1.0.0" });

--- a/src/mcp-stdio-client.test.ts
+++ b/src/mcp-stdio-client.test.ts
@@ -109,7 +109,7 @@ describe.skipIf(!hasTestDb && !dbWasExplicitlyConfigured)(
     });
 
     const transportErrors: Error[] = [];
-    let resolveClosed!: () => void;
+    let resolveClosed: () => void = () => {};
     const closeSeen = new Promise<void>((resolve) => {
       resolveClosed = resolve;
     });


### PR DESCRIPTION
Addresses the Code Quality AI finding in the real stdio MCP client test.\n\nFinding/fix:\n- Replaced the mutable resolver definite-assignment/no-op initializer pattern with `Promise.withResolvers<void>()`, so the close signal remains explicit without introducing another dead assignment.\n\nValidation:\n- `bun test src/mcp-stdio-client.test.ts` (local run skipped the real stdio path because no populated test DB is present)\n- `bun run typecheck`