### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Schema-mismatch setup guidance now points MCP users at a fresh bunx resolution.** The refresh message tells users to restart the MCP client or run `bunx --bun @tikoci/rosetta@latest --refresh` when their cached package is older than the published DB.
+- **Schema-mismatch setup guidance now points MCP users at a fresh bunx resolution.** The refresh message tells users to restart the MCP client or run `bunx @tikoci/rosetta@latest --refresh` when their cached package is older than the published DB.
 
 ## [0.9.1] — 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schema-mismatch setup guidance now points MCP users at a fresh bunx resolution.** The refresh message tells users to restart the MCP client or run `bunx --bun @tikoci/rosetta@latest --refresh` when their cached package is older than the published DB.
+
 ## [0.9.1] — 2026-05-26
 
 ### Fixed

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -475,7 +475,7 @@ export async function downloadDb(
         lastError = new Error(
             `Downloaded DB schema=${probe.schemaVersion} does not match this rosetta build (expected ${SCHEMA_VERSION}). ` +
             `This usually means your MCP client is still using a cached older package version. ` +
-            `Restart the MCP client to let bunx re-resolve the latest package, or run: bunx --bun @tikoci/rosetta@latest --refresh`,
+          `Restart the MCP client to let bunx re-resolve the latest package, or run: bunx @tikoci/rosetta@latest --refresh`,
         );
         if (isLast) throw lastError;
         log(`  ${lastError.message}`);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -24,6 +24,7 @@ import { gunzipSync } from "bun";
 import { detectMode, resolveBaseDir, resolveDbPath, resolveVersion, SCHEMA_VERSION } from "./paths.ts";
 
 declare const REPO_URL: string;
+const REPLACE_DB_TIMEOUT_MS = 30_000;
 
 const GITHUB_REPO =
   typeof REPO_URL !== "undefined" ? REPO_URL : "tikoci/rosetta";
@@ -301,7 +302,7 @@ function isReplaceRaceError(e: unknown): boolean {
 }
 
 async function replaceDbFile(tmpPath: string, dbPath: string): Promise<void> {
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + REPLACE_DB_TIMEOUT_MS;
   let lastError: unknown = null;
 
   while (Date.now() <= deadline) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,6 +11,7 @@ import { execSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
+  fstatSync,
   openSync,
   readdirSync,
   readSync,
@@ -73,14 +74,12 @@ function dbHasData(dbPath: string): boolean {
 }
 
 function looksLikeSqliteFile(dbPath: string): boolean {
-  if (!existsSync(dbPath)) return false;
-
   let fd: number | null = null;
   try {
-    const stats = statSync(dbPath);
+    fd = openSync(dbPath, "r");
+    const stats = fstatSync(fd);
     if (!stats.isFile() || stats.size < SQLITE_MAGIC.length) return false;
 
-    fd = openSync(dbPath, "r");
     const header = Buffer.alloc(SQLITE_MAGIC.length);
     const bytesRead = readSync(fd, header, 0, header.byteLength, 0);
     return bytesRead === header.byteLength && header.toString("utf8") === SQLITE_MAGIC;
@@ -311,7 +310,6 @@ async function replaceDbFile(tmpPath: string, dbPath: string): Promise<void> {
       return;
     } catch (e) {
       if (!isReplaceRaceError(e)) throw e;
-      lastError = e;
     }
 
     tryUnlink(dbPath);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -475,8 +475,8 @@ export async function downloadDb(
         cleanupDbArtifacts(tmpPath);
         lastError = new Error(
             `Downloaded DB schema=${probe.schemaVersion} does not match this rosetta build (expected ${SCHEMA_VERSION}). ` +
-            `This usually means the cached package version is older than the published DB. ` +
-            `Run: bunx @tikoci/rosetta@latest --refresh`,
+            `This usually means your MCP client is still using a cached older package version. ` +
+            `Restart the MCP client to let bunx re-resolve the latest package, or run: bunx --bun @tikoci/rosetta@latest --refresh`,
         );
         if (isLast) throw lastError;
         log(`  ${lastError.message}`);


### PR DESCRIPTION
Addresses setup-related CodeQL / Code Quality findings.\n\nFindings/fixes:\n- CodeQL #38 (`js/useless-assignment-to-local`): removed the dead store in `replaceDbFile`; only the retry path's final race error is retained for timeout reporting.\n- CodeQL #37 (`js/file-system-race`): `looksLikeSqliteFile` now opens the DB once and uses `fstatSync(fd)` before reading the SQLite header, avoiding the path stat/open race pattern.\n- Code Quality AI finding: kept the schema-mismatch guidance improvement and documented it in `CHANGELOG.md`.\n- CodeQL #36 (`js/file-access-to-http`): challenged/dismissed as a false positive; the URL host, repository, and asset name are constants, and the file-derived package version is only used as a public GitHub Release tag path segment. No local file contents are transmitted.\n\nValidation:\n- `bun test src/setup.test.ts`\n- `bun test src/release.test.ts`\n- `bun run typecheck`