### PR TITLE
Cut release.yml over to extract-docusaurus.ts, retire html_url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,8 @@ jobs:
       # Live-fetches manual.mikrotik.com's /docs tree (same live-network risk
       # class as the retired Confluence download) and populates
       # pages/sections/properties/callouts. --check-counts --strict proves
-      # V-docusaurus-docs-count on every release run — same invocation T-0035
-      # verified at 360/360 pages, zero fetch errors, live.
+      # V-docusaurus-docs-count on every release run, failing the release on
+      # either a count mismatch or a skipped (network-unreachable) check.
       - name: Extract Docusaurus pages, properties, callouts
         run: bun run src/extract-docusaurus.ts --check-counts --strict
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,6 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      html_url:
-        description: >
-          Direct download URL for Confluence HTML export (.zip).
-          For box.mikrotik.com Seafile links, append &dl=1 to get the actual file.
-        required: true
-        type: string
-        default: 'https://box.mikrotik.com/d/df76f0d495284eb1b6a1/files/?p=%2FConfluence-space-export-142553-144.html.zip&dl=1'
       version:
         description: 'Optional release version override (e.g. v0.2.0). Default: v + package.json version.'
         required: false
@@ -121,48 +114,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # ── Download and validate HTML export ──
-
-      - name: Download HTML export
-        run: |
-          echo "Downloading: ${{ inputs.html_url }}"
-          curl -fSL --max-time 600 -o export.zip "${{ inputs.html_url }}"
-          # Validate zip magic bytes (PK = 0x504b)
-          MAGIC=$(xxd -l 2 -p export.zip)
-          if [ "$MAGIC" != "504b" ]; then
-            echo "::error::Downloaded file is not a valid ZIP archive (magic: $MAGIC)"
-            if echo "${{ inputs.html_url }}" | grep -q "box.mikrotik.com"; then
-              echo "::error::Hint: Seafile share links need &dl=1 appended for direct download"
-            fi
-            exit 1
-          fi
-          SIZE=$(du -h export.zip | cut -f1)
-          echo "✓ Downloaded ZIP ($SIZE)"
-
-      - name: Extract HTML and locate ROS directory
-        id: locate
-        run: |
-          # Confluence exports include a bare "/" root entry which causes unzip
-          # to warn ("stripped absolute path spec") and exit with code 2.
-          # The files extract fine — tolerate exit codes 0 and 2.
-          unzip -q export.zip -d html-export || [ $? -eq 2 ]
-          # Find the ROS directory containing Confluence HTML files
-          ROS_DIR=$(find html-export -type d -name "ROS" | head -1)
-          if [ -z "$ROS_DIR" ]; then
-            # Fallback: find any directory with many .html files
-            ROS_DIR=$(find html-export -name "*.html" -type f | head -1 | xargs dirname)
-          fi
-          if [ -z "$ROS_DIR" ] || [ ! -d "$ROS_DIR" ]; then
-            echo "::error::Could not find HTML directory in ZIP archive"
-            exit 1
-          fi
-          HTML_COUNT=$(find "$ROS_DIR" -maxdepth 1 -name "*.html" -type f | wc -l)
-          echo "✓ Found $HTML_COUNT HTML files in $ROS_DIR"
-          if [ "$HTML_COUNT" -lt 50 ]; then
-            echo "::warning::Expected ~317 HTML files but found only $HTML_COUNT"
-          fi
-          echo "ros_dir=$ROS_DIR" >> "$GITHUB_OUTPUT"
-
       - name: Resolve release version
         id: release_version
         run: |
@@ -182,11 +133,13 @@ jobs:
 
       # ── Extraction pipeline ──
 
-      - name: Extract HTML pages
-        run: bun run src/extract-html.ts "${{ steps.locate.outputs.ros_dir }}"
-
-      - name: Extract properties
-        run: bun run src/extract-properties.ts "${{ steps.locate.outputs.ros_dir }}"
+      # Live-fetches manual.mikrotik.com's /docs tree (same live-network risk
+      # class as the retired Confluence download) and populates
+      # pages/sections/properties/callouts. --check-counts --strict proves
+      # V-docusaurus-docs-count on every release run — same invocation T-0035
+      # verified at 360/360 pages, zero fetch errors, live.
+      - name: Extract Docusaurus pages, properties, callouts
+        run: bun run src/extract-docusaurus.ts --check-counts --strict
 
       - name: Extract command tree
         run: |
@@ -322,7 +275,7 @@ jobs:
           set -euo pipefail
           fail=0
           if [ "${PAGES:-0}" -lt 200 ]; then
-            echo "::error::DB has only ${PAGES} pages — expected ≥200 (latest export is 317). Aborting release."
+            echo "::error::DB has only ${PAGES} pages — expected ≥200 (Docusaurus /docs export is ~365). Aborting release."
             fail=1
           fi
           if [ "${COMMANDS:-0}" -lt 1000 ]; then
@@ -334,7 +287,7 @@ jobs:
             fail=1
           fi
           if [ "${PROPERTIES:-0}" -lt 1000 ]; then
-            echo "::error::DB has only ${PROPERTIES} properties — expected ≥1000 (current export is ~4860). Aborting release."
+            echo "::error::DB has only ${PROPERTIES} properties — expected ≥1000 (Docusaurus export is ~4,509). Aborting release."
             fail=1
           fi
           if [ "$fail" = "1" ]; then exit 1; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ uses [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **Relative Markdown links inside property descriptions now resolve to live `manual.mikrotik.com` URLs** instead of being left as broken relative paths once extracted out of their source page.
+- **`release.yml` CI now builds the DB from the live Docusaurus extractor, not the legacy Confluence HTML export.** The `html_url` workflow input is gone; a new `extract-docusaurus.ts --check-counts --strict` step proves the docs-count invariant on every release run instead of only in manual/local runs. Rebuilding a historical pre-migration DB remains possible via the local-only `make extract-legacy-confluence` target — it is no longer reachable from CI.
 
 ## [0.10.0] — 2026-07-08
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -382,7 +382,7 @@ macOS Gatekeeper and Windows SmartScreen warn on unsigned binaries. For v0.1 tes
 
 ### CI release workflow for provenance
 
-Local `make release` works but builds are only as trustworthy as the laptop. The `release.yml` GitHub Actions workflow runs the same legacy extraction pipeline from a remote Confluence HTML export URL, creating a release with a traceable commit SHA, CI log, and DB stats in the release notes. This also prepares for eventual NPM publishing — CI-built artifacts have verifiable provenance. The Docusaurus migration will need a different source input, but should preserve this CI-built provenance model.
+Local `make release` works but builds are only as trustworthy as the laptop. The `release.yml` GitHub Actions workflow live-fetches manual.mikrotik.com's `/docs` tree via `extract-docusaurus.ts --check-counts --strict` (T-0036, cut over 2026-07-08 — the legacy Confluence HTML export pipeline is retired from this workflow entirely, surviving only as the local-only `make extract-legacy-confluence` target), creating a release with a traceable commit SHA, CI log, and DB stats in the release notes. This also prepares for eventual NPM publishing — CI-built artifacts have verifiable provenance.
 
 ### OCI image build: Dockerfile + docker buildx
 
@@ -507,7 +507,7 @@ What was built, in rough order (March 2026):
 5. **MCP server** — `mcp.ts` + `query.ts`. 11 tools with compound term recognition, BM25 ranking, AND→OR fallback.
 6. **Knowledge boundaries** — Tool descriptions document data currency (March 2026 export, 7.9–7.23beta2 versions, no v6).
 7. **Distribution** — Compiled single-file binaries via `bun build --compile`, `--setup` mode for DB download + MCP client config, GitHub Releases for assets.
-8. **CI release workflow** — `release.yml` workflow_dispatch: download legacy HTML export from URL → extraction pipeline → quality gate → build artifacts → create GitHub Release. Establishes provenance for eventual NPM publishing.
+8. **CI release workflow** — `release.yml` workflow_dispatch: extraction pipeline → quality gate → build artifacts → create GitHub Release. Establishes provenance for eventual NPM publishing. Originally downloaded a legacy Confluence HTML export by URL; cut over to the live Docusaurus extractor in T-0036 (2026-07-08).
 9. **HTTP transport** — Streamable HTTP via `--http` flag for remote/LAN MCP clients (ChatGPT Apps, OpenAI platform). Uses `Bun.serve()` + `WebStandardStreamableHTTPServerTransport`. Optional TLS.
 10. **MCP Registry metadata** — `server.json` manifest + CI validation for official registry publication.
 11. **North Star (April 2026)** — Regex classifier (`classify.ts`) + `searchAll()` wrapper. Unified `routeros_search` now returns pages + `related` (command_node, properties, devices, callouts, videos, changelogs, skills, glossary) + classifier-informed `next_steps`. Folded `routeros_search_callouts` / `routeros_search_videos` into `related`. MCP tool count 15 → 13.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -507,7 +507,7 @@ What was built, in rough order (March 2026):
 5. **MCP server** — `mcp.ts` + `query.ts`. 11 tools with compound term recognition, BM25 ranking, AND→OR fallback.
 6. **Knowledge boundaries** — Tool descriptions document data currency (March 2026 export, 7.9–7.23beta2 versions, no v6).
 7. **Distribution** — Compiled single-file binaries via `bun build --compile`, `--setup` mode for DB download + MCP client config, GitHub Releases for assets.
-8. **CI release workflow** — `release.yml` workflow_dispatch: extraction pipeline → quality gate → build artifacts → create GitHub Release. Establishes provenance for eventual NPM publishing. Originally downloaded a legacy Confluence HTML export by URL; cut over to the live Docusaurus extractor in T-0036 (2026-07-08).
+8. **CI release workflow** — `release.yml` workflow_dispatch: quality gate → extraction pipeline → build artifacts → create GitHub Release. Establishes provenance for eventual NPM publishing. Originally downloaded a legacy Confluence HTML export by URL; cut over to the live Docusaurus extractor in T-0036 (2026-07-08).
 9. **HTTP transport** — Streamable HTTP via `--http` flag for remote/LAN MCP clients (ChatGPT Apps, OpenAI platform). Uses `Bun.serve()` + `WebStandardStreamableHTTPServerTransport`. Optional TLS.
 10. **MCP Registry metadata** — `server.json` manifest + CI validation for official registry publication.
 11. **North Star (April 2026)** — Regex classifier (`classify.ts`) + `searchAll()` wrapper. Unified `routeros_search` now returns pages + `related` (command_node, properties, devices, callouts, videos, changelogs, skills, glossary) + classifier-informed `next_steps`. Folded `routeros_search_callouts` / `routeros_search_videos` into `related`. MCP tool count 15 → 13.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -170,12 +170,12 @@ Before cutting a corpus release, check these inputs separately from CI:
 
 Published artifacts come from the GitHub Actions `Release` workflow (`workflow_dispatch`), not from local ad hoc release commands.
 
-- **Inputs:** `html_url` (required for the legacy Confluence pipeline), `version` (optional override), `docs_date`, `full_versions`, and `republish_assets`.
+- **Inputs:** `version` (optional override), `docs_date`, `full_versions`, and `republish_assets`.
 - **`republish_assets`:** reuploads GitHub Release assets and OCI tags for an existing version. It does **not** republish npm because npm versions are immutable.
-- **Traceable pipeline:** early quality gate → download/validate legacy HTML export → extraction chain → transcript/Dude cache imports → skill extraction → command linking → `schema_node_presence` GC → DB-wipe guard → contract/eval steps → `db_meta` stamping → minimum-content validation → build/publish release assets and OCI images.
+- **Traceable pipeline:** early quality gate → live Docusaurus extraction (`extract-docusaurus.ts --check-counts --strict`, proving `V-docusaurus-docs-count` on every run) → extraction chain → transcript/Dude cache imports → skill extraction → command linking → `schema_node_presence` GC → DB-wipe guard → contract/eval steps → `db_meta` stamping → minimum-content validation → build/publish release assets and OCI images.
 - **Provenance:** release notes include DB stats, and the stamped `db_meta` keys (`release_tag`, `built_at`, `source_commit`, `schema_version`) let runtime surfaces report exactly what shipped.
 
-For Seafile-hosted legacy HTML exports (`box.mikrotik.com`), append `&dl=1` to force direct download in CI. This release input is expected to change when Docusaurus extraction replaces the Confluence pipeline.
+The legacy Confluence pipeline (`extract-html.ts`/`extract-properties.ts`, `html_url` input) has been retired from `release.yml` (T-0036) — it survives only as the local-only `make extract-legacy-confluence` target for rebuilding historical pre-migration DBs; see "Rebuilding a historical (pre-migration) Confluence release DB" above.
 
 ## Database (Standalone)
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -41,7 +41,7 @@ Tasks in `tasks/` reference these IDs in their `validation:` frontmatter. When a
 | V-schema-roundtrip       | Schema importer round-trip preserves arch diffs, completion, desc parsing                                            | `src/schema-roundtrip.test.ts`                                         | blocking                                     | —          |
 | V-extract-videos         | yt-dlp extractor handles cache save/import/known-bad correctly                                                       | `src/extract-videos.test.ts`                                           | blocking                                     | —          |
 | V-docusaurus-parse-shape | Docusaurus Markdown parsing (properties incl. malformed-emphasis, admonitions, sections, link resolution) matches fixture-verified expectations | `src/extract-docusaurus.test.ts` against `fixtures/docusaurus/*.md`    | blocking                                     | —          |
-| V-docusaurus-docs-count  | Extracted `/docs` page count exactly matches the scoped `llms.txt` in-scope entry count (B-0012 H8)                  | `extract-docusaurus.ts --check-counts` (`make extract-docusaurus-check-counts`) — live-network, not run in `bun test`/CI yet | non-blocking (manual/local run only) | T-0035 follow-up: wire into CI once a committed full-corpus cache or scheduled live run exists |
+| V-docusaurus-docs-count  | Extracted `/docs` page count exactly matches the scoped `llms.txt` in-scope entry count (B-0012 H8)                  | `Extract Docusaurus pages, properties, callouts` step (`extract-docusaurus.ts --check-counts --strict`) in `.github/workflows/release.yml` | blocking (release.yml) | —          |
 
 ## How to add a row
 

--- a/src/extract-docusaurus.ts
+++ b/src/extract-docusaurus.ts
@@ -467,11 +467,14 @@ async function checkCounts(extractedCount: number): Promise<boolean> {
     const llmsTxt = await res.text();
     const expected = parseLlmsTxtInScopeCount(llmsTxt);
     const ok = expected === extractedCount;
-    console.log(`\nCount cross-check (V-docusaurus-docs-count, non-blocking): llms.txt in-scope=${expected}, extracted=${extractedCount} — ${ok ? "MATCH" : "MISMATCH"}`);
+    console.log(`\nCount cross-check (V-docusaurus-docs-count${STRICT ? "" : ", non-blocking"}): llms.txt in-scope=${expected}, extracted=${extractedCount} — ${ok ? "MATCH" : "MISMATCH"}`);
     return ok;
   } catch (e) {
     console.log(`\nCount cross-check skipped (fetch failed): ${e}`);
-    return true; // don't fail a run just because the cross-check itself couldn't reach the network
+    // Plain --check-counts (local/manual) stays soft: a network blip shouldn't fail
+    // a dev run. But --strict is release.yml's blocking use (V-docusaurus-docs-count) —
+    // there, a skipped cross-check must not silently read as a pass.
+    return !STRICT;
   }
 }
 

--- a/src/release.test.ts
+++ b/src/release.test.ts
@@ -407,6 +407,8 @@ describe("release.yml", () => {
   test("has required inputs", () => {
     const src = readText(".github/workflows/release.yml");
     expect(src).not.toContain("html_url:");
+    expect(src).not.toContain("extract-html.ts");
+    expect(src).not.toContain("extract-properties.ts");
     expect(src).toContain("version:");
     expect(src).toContain("republish_assets:");
     expect(src).not.toContain("inputs.force");

--- a/src/release.test.ts
+++ b/src/release.test.ts
@@ -406,28 +406,30 @@ describe("release.yml", () => {
 
   test("has required inputs", () => {
     const src = readText(".github/workflows/release.yml");
-    expect(src).toContain("html_url:");
+    expect(src).not.toContain("html_url:");
     expect(src).toContain("version:");
     expect(src).toContain("republish_assets:");
     expect(src).not.toContain("inputs.force");
   });
 
-  test("tolerates Confluence zip with absolute path root entry", () => {
-    const src = readText(".github/workflows/release.yml");
-    // Confluence exports include a bare "/" entry → unzip exits 2
-    expect(src).toMatch(/unzip.*\|\|.*\$\?.*-eq.*2/);
-  });
-
   test("runs extraction pipeline", () => {
     const src = readText(".github/workflows/release.yml");
-    expect(src).toContain("extract-html.ts");
-    expect(src).toContain("extract-properties.ts");
+    expect(src).toContain("extract-docusaurus.ts");
     expect(src).toContain("extract-commands.ts");
     expect(src).toContain("extract-devices.ts");
     expect(src).toContain("extract-test-results.ts");
     expect(src).toContain("extract-changelogs.ts");
     expect(src).toContain("extract-skills.ts");
     expect(src).toContain("link-commands.ts");
+  });
+
+  test("Docusaurus extraction step proves the docs-count invariant, not just a manual/local run", () => {
+    const src = readText(".github/workflows/release.yml");
+    const extractIdx = mustIndex(src, "Extract Docusaurus pages, properties, callouts");
+    const commandTreeIdx = mustIndex(src, "Extract command tree");
+    const extractBlock = src.slice(extractIdx, commandTreeIdx);
+
+    expect(extractBlock).toContain("extract-docusaurus.ts --check-counts --strict");
   });
 
   test("imports Dude wiki from cache", () => {
@@ -454,30 +456,30 @@ describe("release.yml", () => {
     expect(src).toContain("bun run lint");
   });
 
-  test("runs early quality gate before downloading HTML export", () => {
+  test("runs early quality gate before Docusaurus extraction", () => {
     const src = readText(".github/workflows/release.yml");
     const installIdx = mustIndex(src, "bun install");
     const typecheckIdx = mustIndex(src, "Type check (fast-fail)");
     const lintIdx = mustIndex(src, "Lint (fast-fail)");
     const earlyTestIdx = mustIndex(src, "Run tests (fast-fail)");
-    const downloadIdx = mustIndex(src, "Download HTML export");
+    const extractIdx = mustIndex(src, "Extract Docusaurus pages, properties, callouts");
 
     expect(installIdx).toBeLessThan(typecheckIdx);
     expect(typecheckIdx).toBeLessThan(lintIdx);
     expect(lintIdx).toBeLessThan(earlyTestIdx);
-    expect(earlyTestIdx).toBeLessThan(downloadIdx);
+    expect(earlyTestIdx).toBeLessThan(extractIdx);
   });
 
   test("preflights npm publish access before release side effects", () => {
     const src = readText(".github/workflows/release.yml");
     const preflightIdx = mustIndex(src, "Verify npm publish access");
-    const downloadIdx = mustIndex(src, "Download HTML export");
+    const extractIdx = mustIndex(src, "Extract Docusaurus pages, properties, callouts");
     const ociIdx = mustIndex(src, "Build and push OCI images");
     const releaseIdx = mustIndex(src, "Create or update GitHub Release");
     const publishIdx = mustIndex(src, "Publish to npm");
-    const preflightBlock = src.slice(preflightIdx, downloadIdx);
+    const preflightBlock = src.slice(preflightIdx, extractIdx);
 
-    expect(preflightIdx).toBeLessThan(downloadIdx);
+    expect(preflightIdx).toBeLessThan(extractIdx);
     expect(preflightIdx).toBeLessThan(ociIdx);
     expect(preflightIdx).toBeLessThan(releaseIdx);
     expect(preflightIdx).toBeLessThan(publishIdx);

--- a/tasks/T-0036-release-yml-docusaurus-cutover.md
+++ b/tasks/T-0036-release-yml-docusaurus-cutover.md
@@ -1,7 +1,7 @@
 ---
 id: T-0036-release-yml-docusaurus-cutover
 title: Cut release.yml over to extract-docusaurus.ts, retire html_url
-status: ready
+status: in-progress
 priority: high
 area: release
 depends_on: []

--- a/tasks/done/T-0036-release-yml-docusaurus-cutover.md
+++ b/tasks/done/T-0036-release-yml-docusaurus-cutover.md
@@ -1,7 +1,7 @@
 ---
 id: T-0036-release-yml-docusaurus-cutover
 title: Cut release.yml over to extract-docusaurus.ts, retire html_url
-status: in-progress
+status: done 
 priority: high
 area: release
 depends_on: []


### PR DESCRIPTION
## Summary

- `release.yml` no longer downloads a live Confluence HTML export via `html_url`. A single new step (`Extract Docusaurus pages, properties, callouts`) runs `bun run src/extract-docusaurus.ts --check-counts --strict` in place of the retired `Download HTML export` / `Extract HTML and locate ROS directory` / `Extract HTML pages` / `Extract properties` steps.
- `V-docusaurus-docs-count` (VALIDATION.md) is promoted from "non-blocking (manual/local run only)" to **blocking** — `--strict` fails the release if the extracted `/docs` page count doesn't exactly match `llms.txt`'s scoped entry count.
- `Validate DB has expected content` floors (pages≥200, properties≥1000) unchanged — still comfortably below the real Docusaurus corpus size — but their informational reference numbers refreshed to match a live-verified run (see Test plan).
- Legacy Confluence pipeline (`extract-html.ts`/`extract-properties.ts`) is now unreachable from CI; it survives only as the local-only `make extract-legacy-confluence` target, matching how `Makefile`/`DESIGN.md` already framed it since T-0035.
- `src/release.test.ts`, `MANUAL.md`, `DESIGN.md`, `CHANGELOG.md`, `VALIDATION.md` updated to match.

Scoped and reviewed in `briefings/B-0014-ci-testing-qa-cleanup.md` ("2026-07-08 follow-up"); full acceptance criteria in `tasks/T-0036-release-yml-docusaurus-cutover.md`.

**Deliberately not done in this PR:** a real `workflow_dispatch` of `release.yml`. Today's workflow has no `--tag` mechanism yet (that's `T-0037`, which depends on this PR), so any dispatch would either publish `0.11.0` to npm's `latest` dist-tag or — even with `republish_assets: true` — clobber the `:latest` OCI tag on Docker Hub/GHCR. `latest` must stay pinned to `0.10.0` until `T-0037` lands its tag-gating. The plan is to prove this workflow in CI via the *first tagged prerelease dispatch* under `T-0037`, not a standalone dispatch here.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 637 pass, 0 fail (repo-wide)
- [x] `bun test src/release.test.ts` — 102 pass, 0 fail
- [x] Live-ran the exact new step's invocation locally (no publish, no CI): `bun run src/extract-docusaurus.ts --check-counts --strict` → 365/365 pages, 0 fetch errors, exact `llms.txt` count match, exit 0
- [ ] Real `workflow_dispatch` of `release.yml` — intentionally deferred to `T-0037` (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now use live Docusaurus documentation content for database generation and verification.
  * Release runs now include stricter documentation count checks before publishing.

* **Documentation**
  * Updated release, design, validation, and changelog docs to reflect the new release flow and required inputs.

* **Bug Fixes**
  * Removed reliance on the legacy HTML export path from the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->