### PR TITLE
Security & Quality sweep: consolidate #44 + #46, CodeQL, changelog links, branch protection + review-bot config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Staged review to conserve the org's prepaid CodeRabbit credits (the default —
+# review every PR + every incremental push — exhausts them). Policy:
+#   - review only when a PR is marked ready-for-review (skip drafts)
+#   - one review per ready PR; no automatic per-commit incremental re-reviews
+#   - re-review on demand with an `@coderabbitai review` PR comment
+# If the OSS rate limit becomes painful, the next step is to set
+# reviews.auto_review.enabled=false and have a workflow_run job comment
+# `@coderabbitai review` only after CI succeeds for the PR head SHA.
+#
+# Terse/no-decoration policy: both reviews.poem and reviews.in_progress_fortune
+# default to true, so both `false` settings here are load-bearing, not redundant.
+#
+# CodeRabbit ignores .coderabbit.yaml changes made *within* an open PR ("only the
+# configuration from the base branch is applied") — any edit here only takes
+# effect starting with the PR opened *after* this file's change merges to `main`,
+# never in the PR that introduces the change itself.
+language: en-US
+tone_instructions: >
+  Terse and actionable. No poems, jokes, or decorative filler. State the
+  finding, the file/line, and the fix. Skip praise and preamble.
+reviews:
+  profile: assertive
+  review_details: true
+  enable_prompt_for_ai_agents: true
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: false
+    ignore_usernames:
+      - dependabot[bot]
+  tools:
+    github-checks:
+      enabled: true
+      timeout_ms: 420000
+  poem: false
+  in_progress_fortune: false
+  # Skip generated data / caches / large binary-ish artifacts — code and docs
+  # are the review surface, not the extracted corpus.
+  path_filters:
+    - "!fixtures/**"
+    - "!manual/**"
+    - "!transcripts/**"
+    - "!*.tsv"
+    - "!*.db"

--- a/.github/instructions/pr-review-bots.instructions.md
+++ b/.github/instructions/pr-review-bots.instructions.md
@@ -32,8 +32,12 @@ Findings live in **inline review comments**, which `gh pr view` does not show. R
 them explicitly, then close the loop:
 
 ```sh
-# All inline review comments (Copilot + CodeRabbit), path:line + body:
-gh api repos/tikoci/rosetta/pulls/N/comments --jq '.[] | "\(.user.login) \(.path):\(.line)\n\(.body)\n"'
+# All inline review comments (Copilot + CodeRabbit), path:line + body.
+# --paginate: the endpoint is paged, so without it you only see the first page.
+# .line // .original_line: outdated comments carry line:null; fall back so the
+# location prints instead of "path:null".
+gh api --paginate repos/tikoci/rosetta/pulls/N/comments \
+  --jq '.[] | "\(.user.login) \(.path):\(.line // .original_line)\n\(.body)\n"'
 ```
 
 For each finding: fix it, or dismiss it with a grounded reason. **Replying to a thread
@@ -42,8 +46,9 @@ does not resolve it** — resolving is a separate, explicit action. You own bot 
 thread on their behalf. List and resolve still-open threads:
 
 ```sh
-# Still-unresolved threads:
-gh api graphql -f query='query{repository(owner:"tikoci",name:"rosetta"){pullRequest(number:N){reviewThreads(first:50){nodes{id isResolved path line}}}}}' \
+# Still-unresolved threads (first:100 is the GraphQL max — on a PR with more
+# threads than that, page with `after:` cursors so none are silently hidden):
+gh api graphql -f query='query{repository(owner:"tikoci",name:"rosetta"){pullRequest(number:N){reviewThreads(first:100){nodes{id isResolved path line}}}}}' \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)|"\(.id)\t\(.path):\(.line)"'
 # Resolve one (repeat per id):
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=THREAD_ID

--- a/.github/instructions/pr-review-bots.instructions.md
+++ b/.github/instructions/pr-review-bots.instructions.md
@@ -1,0 +1,46 @@
+---
+description: "How Copilot and CodeRabbit reviews manifest on a rosetta PR, why each looks different from a `gh` point of view, and what 'wrapping a PR' actually requires."
+applyTo: "src/**, bin/**, scripts/**, .github/**, *.md, tasks/**, briefings/**"
+---
+# PR review bots (Copilot + CodeRabbit)
+
+When a rosetta PR is marked **Ready for Review** (not while it is a draft), **two**
+bots review it: `copilot-pull-request-reviewer` and `coderabbitai`. They surface
+their findings through *different* GitHub mechanisms, so an agent that checks only
+one signal will mis-read the state of the PR.
+
+- **CodeRabbit is a status check, not a findings gate.** Its check turns **green when
+  its review run finishes** — green means "CodeRabbit is done looking," **not** "your
+  findings are addressed." Do not read a green CodeRabbit check as permission to merge.
+  It re-reviews on demand via an `@coderabbitai review` PR comment.
+- **Copilot is a requested reviewer.** Its review lands as state **`COMMENTED`**, never
+  `CHANGES_REQUESTED`. So `gh pr view N --json reviewDecision` will **not** show it as
+  blocking or pending the way a human "changes requested" review would — the findings
+  are real but invisible to a decision-status check.
+- **Neither bot blocks the merge button.** `main` is not branch-protected here and both
+  bots submit `COMMENTED`, so `mergeStateStatus` / `reviewDecision` can read clean while
+  unaddressed findings sit in inline threads. Checking merge status is **not** a proxy
+  for "review handled."
+
+## Wrapping a PR
+
+Findings live in **inline review comments**, which `gh pr view` does not show. Read
+them explicitly, then close the loop:
+
+```sh
+# All inline review comments (Copilot + CodeRabbit), path:line + body:
+gh api repos/tikoci/rosetta/pulls/N/comments --jq '.[] | "\(.user.login) \(.path):\(.line)\n\(.body)\n"'
+```
+
+For each finding: fix it, or dismiss it with a grounded reason. **Replying to a thread
+does not resolve it** — resolving is a separate, explicit action. You own bot threads
+(Copilot/CodeRabbit) once the finding is handled; do not resolve a *human* reviewer's
+thread on their behalf. List and resolve still-open threads:
+
+```sh
+# Still-unresolved threads:
+gh api graphql -f query='query{repository(owner:"tikoci",name:"rosetta"){pullRequest(number:N){reviewThreads(first:50){nodes{id isResolved path line}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)|"\(.id)\t\(.path):\(.line)"'
+# Resolve one (repeat per id):
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=THREAD_ID
+```

--- a/.github/instructions/pr-review-bots.instructions.md
+++ b/.github/instructions/pr-review-bots.instructions.md
@@ -17,10 +17,14 @@ one signal will mis-read the state of the PR.
   `CHANGES_REQUESTED`. So `gh pr view N --json reviewDecision` will **not** show it as
   blocking or pending the way a human "changes requested" review would — the findings
   are real but invisible to a decision-status check.
-- **Neither bot blocks the merge button.** `main` is not branch-protected here and both
-  bots submit `COMMENTED`, so `mergeStateStatus` / `reviewDecision` can read clean while
-  unaddressed findings sit in inline threads. Checking merge status is **not** a proxy
-  for "review handled."
+- **Bot reviews don't move `reviewDecision`, but unresolved threads DO block the merge.**
+  `main` is branch-protected: **required status checks** (`test`, both CodeQL `Analyze`)
+  plus **required conversation resolution**, with `enforce_admins: false` (an admin can
+  still override the button, or merge via `gh`). Because both bots submit `COMMENTED`
+  (never `CHANGES_REQUESTED`), `gh pr view N --json reviewDecision` stays clean — the
+  block surfaces as `mergeStateStatus: BLOCKED`, driven by the **unresolved review
+  threads**, not by a review decision. So `reviewDecision` is *not* the signal to watch;
+  an open bot thread is. Resolving every thread (below) is what clears the gate.
 
 ## Wrapping a PR
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Review dependency changes
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -98,7 +98,7 @@ jobs:
     name: QA • ${{ inputs.test_scope }} • ${{ inputs.db_source }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # workflow_call inputs are free-form strings, so a typo (e.g. test_scope:
       # db_content with an underscore) would otherwise skip every gated step and
@@ -201,7 +201,7 @@ jobs:
       # eval/contract resolve it via paths.ts dev-mode, same as the other two sources.
       - name: Download build artifact (artifact)
         if: inputs.db_source == 'artifact'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       hardware_catalog: ${{ steps.stats.outputs.hardware_catalog }}
       device_aliases: ${{ steps.stats.outputs.device_aliases }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -417,7 +417,7 @@ jobs:
     outputs:
       version: ${{ needs.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -430,7 +430,7 @@ jobs:
 
       # The DB that passed the qa gates — the ONLY DB that reaches publishing.
       - name: Download built DB artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ros-help-db
           path: .
@@ -439,7 +439,7 @@ jobs:
       # version) over the committed one, so npm publishes the exact version
       # build computed and validated.
       - name: Download resolved package.json
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: release-package-json
           path: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install mcp-publisher
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,6 +653,16 @@ Initial public release.
 - Bun tests for the query planner + schema health.
 
 [Unreleased]: https://github.com/tikoci/rosetta/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/tikoci/rosetta/compare/v0.9.3...v0.10.0
+[0.9.3]: https://github.com/tikoci/rosetta/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/tikoci/rosetta/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/tikoci/rosetta/compare/v0.8.13...v0.9.1
+[0.8.13]: https://github.com/tikoci/rosetta/compare/v0.8.12...v0.8.13
+[0.8.12]: https://github.com/tikoci/rosetta/compare/v0.8.11...v0.8.12
+[0.8.11]: https://github.com/tikoci/rosetta/compare/v0.8.10...v0.8.11
+[0.8.10]: https://github.com/tikoci/rosetta/compare/v0.8.9...v0.8.10
+[0.8.9]: https://github.com/tikoci/rosetta/compare/v0.8.8...v0.8.9
+[0.8.8]: https://github.com/tikoci/rosetta/compare/v0.8.3...v0.8.8
 [0.8.2 – 0.8.3]: https://github.com/tikoci/rosetta/compare/v0.8.1...v0.8.3
 [0.8.0 – 0.8.1]: https://github.com/tikoci/rosetta/compare/v0.7.8...v0.8.1
 [0.7.5 – 0.7.8]: https://github.com/tikoci/rosetta/compare/v0.7.4...v0.7.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,7 +652,7 @@ Initial public release.
   dev / package at `~/.rosetta/`).
 - Bun tests for the query planner + schema health.
 
-[Unreleased]: https://github.com/tikoci/rosetta/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/tikoci/rosetta/compare/v0.10.0...HEAD
 [0.8.2 – 0.8.3]: https://github.com/tikoci/rosetta/compare/v0.8.1...v0.8.3
 [0.8.0 – 0.8.1]: https://github.com/tikoci/rosetta/compare/v0.7.8...v0.8.1
 [0.7.5 – 0.7.8]: https://github.com/tikoci/rosetta/compare/v0.7.4...v0.7.8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Agent-specific entrypoints are thin shims: Claude starts here, Codex starts with
 | Extraction and data-shape work | `extraction.instructions.md` plus `extractor-idempotent.instructions.md`, `extractor-import-side-effects.instructions.md`, `command-versions-vs-presence.instructions.md`, `schema-roundtrip-compat.instructions.md`, `data-source-naming-product-matrix.instructions.md`, `skill-attribution-boundary.instructions.md` |
 | Release / install / provenance | `release-via-ci.instructions.md`, `republish-assets-not-npm.instructions.md`, `db-meta-stamping.instructions.md` |
 | Markdown / doc-authoring rules | `markdownlint-fenced-code.instructions.md`, `llm-instruction-files-excluded-from-mdlint.instructions.md` |
-| Issue / briefing workflow | `tasks-vs-briefings.instructions.md`, `issue-pr-linking.instructions.md`, `tasks/README.md`, `briefings/README.md` |
+| Issue / briefing workflow | `tasks-vs-briefings.instructions.md`, `issue-pr-linking.instructions.md`, `pr-review-bots.instructions.md`, `tasks/README.md`, `briefings/README.md` |
 
 ## Fast pointers
 

--- a/device-map.tsv
+++ b/device-map.tsv
@@ -54,7 +54,7 @@ CSS326-24G-2S+RM	CSS326-24G-2S+RM	Switches	auto	https://manual.mikrotik.com/hard
 CSS610-8G-2S+IN	CSS610-8G-2S+IN	Switches	auto	https://manual.mikrotik.com/hardware/css610-8g-2s-plus-in	https://mikrotik.com/product/css610_8g_2s_in		
 CSS610-8P-2S+IN	CSS610-8P-2S+IN	Switches	auto	https://manual.mikrotik.com/hardware/css610-8p-2s-plus-in	https://mikrotik.com/product/css610_8p_2s_in		
 Cube 60Pro ac	CubeG-5ac60ay	60 GHz products	auto	https://manual.mikrotik.com/hardware/wireless-wire-cube-pro-cube-60pro-ac	https://mikrotik.com/product/cube_60pro_ac		
-CubeSA 60Pro ac	CubeG-5ac60ay-SA		curated-alias	https://manual.mikrotik.com/hardware/wireless-wire-cube-pro-cube-60pro-ac	https://mikrotik.com/product/cubesa_60pro_ac	curated-alias	MikroTik combines two products on one /hardware page; this SA variant's own www product is cubesa_60pro_ac.
+CubeSA 60Pro ac	CubeG-5ac60ay-SA		curated-alias	https://manual.mikrotik.com/hardware/wireless-wire-cube-pro-cube-60pro-ac	https://mikrotik.com/product/cubesa_60pro_ac		MikroTik combines two products on one /hardware page; this SA variant's own www product is cubesa_60pro_ac.
 FiberBox Plus	CRS305-1G-4S+OUTr2	Switches	auto	https://manual.mikrotik.com/hardware/fiberbox-plus	https://mikrotik.com/product/fiberboxplus		
 FTC11XG	FTC11XG	Accessories	auto	https://manual.mikrotik.com/hardware/ftc11xg	https://mikrotik.com/product/ftc11xg		
 FTC21-ups	FTC21-ups		no-hardware-page		https://mikrotik.com/product/ftc21_ups	no-hardware-page	www product ftc21_ups exists (was never a fetch candidate); the /hardware/ftc21 page is the non-ups variant, so there is no /hardware page for the -ups SKU.
@@ -85,8 +85,8 @@ hEX refresh	E50UG	Ethernet routers	auto	https://manual.mikrotik.com/hardware/hex
 hEX S	RB760iGS	Ethernet routers	auto	https://manual.mikrotik.com/hardware/hex-s	https://mikrotik.com/product/hex_s		
 hEX S (2025)	E60iUGS	Ethernet routers	auto	https://manual.mikrotik.com/hardware/hex-s-2025	https://mikrotik.com/product/hex_s_2025		
 KNOT	RB924i-2nD-BT5&BG77r2	IoT products	auto	https://manual.mikrotik.com/hardware/rb924i-2nd-bt5-and-bg77	https://mikrotik.com/product/knot		
-KNOT Embedded LTE4	EC25-EU&KNe		curated-alias	https://manual.mikrotik.com/hardware/knot-embedded-lte4-ec25-eu-and-kne	https://mikrotik.com/product/knot_emb_lte4_global	curated-alias	Page slug prefixes the friendly name onto the &-compound code; www uses the shared _global product.
-KNOT Embedded LTE4 Global	EG25-G&KNe		curated-alias	https://manual.mikrotik.com/hardware/knot-embedded-lte4-global-eg25-g-and-kne	https://mikrotik.com/product/knot_emb_lte4_global	curated-alias	Same shared www product as KNOT Embedded LTE4.
+KNOT Embedded LTE4	EC25-EU&KNe		curated-alias	https://manual.mikrotik.com/hardware/knot-embedded-lte4-ec25-eu-and-kne	https://mikrotik.com/product/knot_emb_lte4_global		Page slug prefixes the friendly name onto the &-compound code; www uses the shared _global product.
+KNOT Embedded LTE4 Global	EG25-G&KNe		curated-alias	https://manual.mikrotik.com/hardware/knot-embedded-lte4-global-eg25-g-and-kne	https://mikrotik.com/product/knot_emb_lte4_global		Same shared www product as KNOT Embedded LTE4.
 KNOT LR8G kit	RB924iR-2nD-BT5&BG770A&R11e-LR8G	IoT products	auto	https://manual.mikrotik.com/hardware/rb924i-2nd-bt5-and-bg77	https://mikrotik.com/product/knot_lr8g_kit		
 KNOT LR9G kit	RB924iR-2nD-BT5&BG770A&R11e-LR9G	IoT products	auto	https://manual.mikrotik.com/hardware/rb924i-2nd-bt5-and-bg77	https://mikrotik.com/product/knot_lr9g_kit		
 L009UiGS-2HaxD-IN	L009UiGS-2HaxD-IN	Indoor wireless	auto	https://manual.mikrotik.com/hardware/l009uigs-2haxd-in	https://mikrotik.com/product/l009uigs_2haxd_in		
@@ -138,11 +138,11 @@ RB5009UG+S+IN	RB5009UG+S+IN	Ethernet routers	auto	https://manual.mikrotik.com/ha
 RB5009UPr+S+IN	RB5009UPr+S+IN	Ethernet routers	auto	https://manual.mikrotik.com/hardware/rb5009upr-plus-s-plus-in	https://mikrotik.com/product/rb5009upr_s_in		
 RB5009UPr+S+OUT	RB5009UPr+S+OUT	Ethernet routers	auto	https://manual.mikrotik.com/hardware/rb5009upr-plus-s-plus-out	https://mikrotik.com/product/rb5009_out		
 RBM33G	RBM33G	RouterBOARD	auto	https://manual.mikrotik.com/hardware/rbm33g	https://mikrotik.com/product/rbm33g		
-ROSE Data server (RDS)	RDS2216-2XG-4S+4XS-2XQ		curated-alias	https://manual.mikrotik.com/hardware/rose-data-server	https://mikrotik.com/product/rds2216	curated-alias	Marketing name; matrix code RDS2216-2XG-4S+4XS-2XQ, www product rds2216.
+ROSE Data server (RDS)	RDS2216-2XG-4S+4XS-2XQ		curated-alias	https://manual.mikrotik.com/hardware/rose-data-server	https://mikrotik.com/product/rds2216		Marketing name; matrix code RDS2216-2XG-4S+4XS-2XQ, www product rds2216.
 SXT LTE7 kit	SXTR&R11e-LTE7r3	LTE products	auto	https://manual.mikrotik.com/hardware/sxt-r	https://mikrotik.com/product/sxt_r		
 SXT SA5 ac	RBSXTG-5HPacD-SAr2	Wireless systems	auto	https://manual.mikrotik.com/hardware/sxtsa-series	https://mikrotik.com/product/RBSXTG-5HPacD-SAr2		
 SXTsq 5 ac	RBSXTsqG-5acDr2	Wireless systems	auto	https://manual.mikrotik.com/hardware/sxtsq-series	https://mikrotik.com/product/sxtsq_5_ac		
-SXTsq 5 ax	SXTsq-5axD	Wireless systems	curated-alias	https://manual.mikrotik.com/hardware/sxtsq-5axd	https://mikrotik.com/product/sxtsq_5ax	curated-alias	Both pages exist under a slug the matcher can't reach: /hardware/sxtsq-5axd + mikrotik.com/product/sxtsq_5ax (maintainer-confirmed 2026-07-11). The page links only the bogus qm_x, and the www slug drops the trailing 'd', so neither auto-resolves the www side.
+SXTsq 5 ax	SXTsq-5axD	Wireless systems	curated-alias	https://manual.mikrotik.com/hardware/sxtsq-5axd	https://mikrotik.com/product/sxtsq_5ax		Both pages exist under a slug the matcher can't reach: /hardware/sxtsq-5axd + mikrotik.com/product/sxtsq_5ax (maintainer-confirmed 2026-07-11). The page links only the bogus qm_x, and the www slug drops the trailing 'd', so neither auto-resolves the www side.
 SXTsq Embedded LTE4	EC25-EU&SXTsq	LTE products	auto	https://manual.mikrotik.com/hardware/sxtsq-embedded-lte4	https://mikrotik.com/product/sxtsq_emb_lte4		
 SXTsq Embedded LTE4 Global	EG25-G&SXTsq		no-hardware-page		https://mikrotik.com/product/sxtsq_emb_lte4_global	no-hardware-page	www product sxtsq_emb_lte4_global exists; the Global embedded-LTE4 SKU is absent from /hardware (the non-Global SXTsq Embedded LTE4 does have a page).
 SXTsq Lite2	RBSXTsq2nD	Wireless systems	auto	https://manual.mikrotik.com/hardware/sxtsq-series	https://mikrotik.com/product/sxtsq_lite2		

--- a/project-words.txt
+++ b/project-words.txt
@@ -57,6 +57,7 @@ chipset
 cli
 cmdver
 cmp
+coderabbitai
 configur
 conntrack
 cpe

--- a/project-words.txt
+++ b/project-words.txt
@@ -57,6 +57,7 @@ chipset
 cli
 cmdver
 cmp
+coderabbit
 coderabbitai
 configur
 conntrack

--- a/src/assess-www.ts
+++ b/src/assess-www.ts
@@ -150,7 +150,7 @@ async function main() {
   for (const code of codes) {
     const cacheFile = cachePathFor(code);
     let html: string;
-    let status = 200;
+    let status: number;
 
     if (FROM_CACHE) {
       if (!existsSync(cacheFile)) {

--- a/src/build-device-map.ts
+++ b/src/build-device-map.ts
@@ -163,13 +163,10 @@ for (const r of matrixRows) {
   const hwUrl = autoHw || (exc.hardware_slug ? `${HW_BASE}/${exc.hardware_slug}` : "");
   const wwwUrl = autoWww || (exc.www_code ? `${WWW_BASE}/${exc.www_code}` : "");
   const hasBothUrls = Boolean(hwUrl && wwwUrl);
-  const needsReviewClasses = new Set(["no-hardware-page", "no-www-product", "accessory"]);
+  // A curated-alias row with both URLs resolved is fully mapped and needs no review;
+  // every other class carries its own name into needs_review.
   const needsReview =
-    needsReviewClasses.has(exc.class)
-      ? exc.class
-      : exc.class === "curated-alias"
-        ? (hasBothUrls ? "" : exc.class)
-        : exc.class;
+    exc.class === "curated-alias" && hasBothUrls ? "" : exc.class;
   rows.push({
     name: r.name,
     code: r.code,
@@ -208,7 +205,7 @@ async function emitOrCheck(path: string, content: string, label: string): Promis
 function rowsToTsv(headers: readonly string[], dataRows: readonly (readonly unknown[])[]): string {
   return `${[
     headers.join("\t"),
-    ...dataRows.map((row) => row.map((cell) => String(cell).replace(/\t|\n/g, " ")).join("\t")),
+    ...dataRows.map((row) => row.map((cell) => String(cell).replace(/[\t\r\n]/g, " ")).join("\t")),
   ].join("\n")}\n`;
 }
 

--- a/src/build-device-map.ts
+++ b/src/build-device-map.ts
@@ -162,6 +162,14 @@ for (const r of matrixRows) {
   usedExceptions.add(r.name);
   const hwUrl = autoHw || (exc.hardware_slug ? `${HW_BASE}/${exc.hardware_slug}` : "");
   const wwwUrl = autoWww || (exc.www_code ? `${WWW_BASE}/${exc.www_code}` : "");
+  const hasBothUrls = Boolean(hwUrl && wwwUrl);
+  const needsReviewClasses = new Set(["no-hardware-page", "no-www-product", "accessory"]);
+  const needsReview =
+    needsReviewClasses.has(exc.class)
+      ? exc.class
+      : exc.class === "curated-alias"
+        ? (hasBothUrls ? "" : exc.class)
+        : exc.class;
   rows.push({
     name: r.name,
     code: r.code,
@@ -169,7 +177,7 @@ for (const r of matrixRows) {
     resolution: exc.class,
     hw_url: hwUrl,
     www_url: wwwUrl,
-    needs_review: exc.class,
+    needs_review: needsReview,
     note: exc.note ?? "",
   });
 }

--- a/src/build-device-map.ts
+++ b/src/build-device-map.ts
@@ -197,8 +197,15 @@ async function emitOrCheck(path: string, content: string, label: string): Promis
   }
 }
 
+function rowsToTsv(headers: readonly string[], dataRows: readonly (readonly unknown[])[]): string {
+  return `${[
+    headers.join("\t"),
+    ...dataRows.map((row) => row.map((cell) => String(cell).replace(/\t|\n/g, " ")).join("\t")),
+  ].join("\n")}\n`;
+}
+
 const HEADERS: (keyof MapRow)[] = ["name", "code", "category", "resolution", "hw_url", "www_url", "needs_review", "note"];
-const tsv = `${[HEADERS.join("\t"), ...rows.map((row) => HEADERS.map((h) => String(row[h]).replace(/\t|\n/g, " ")).join("\t"))].join("\n")}\n`;
+const tsv = rowsToTsv(HEADERS, rows.map((row) => HEADERS.map((h) => row[h])));
 
 await emitOrCheck(OUT_TSV, tsv, `${rows.length} device rows`);
 
@@ -219,7 +226,7 @@ const unmatchedRows = hwPages
     p.url ?? `${HW_BASE}/${p.slug}`,
     (p.mentionedCodes ?? []).join(" "),
   ]);
-const unmatchedTsv = `${[UNMATCHED_HEADERS.join("\t"), ...unmatchedRows.map((r) => r.map((c) => String(c).replace(/\t|\n/g, " ")).join("\t"))].join("\n")}\n`;
+const unmatchedTsv = rowsToTsv(UNMATCHED_HEADERS, unmatchedRows);
 await emitOrCheck(OUT_UNMATCHED_TSV, unmatchedTsv, `${unmatchedRows.length} unmatched /hardware pages`);
 
 // ── Summary + drift gate ──


### PR DESCRIPTION
Consolidates the open **Security & Quality** housekeeping into one merge. **Supersedes #44 and #46** (both closed in favor of this PR).

## Code / config changes in this PR

| Item | Change |
|------|--------|
| CodeQL `js/useless-assignment-to-local` (**#42**) | `src/assess-www.ts` — drop the dead `= 200` initializer on `status`. |
| Dependabot **#46** | `actions/checkout` v6→v7 (5 workflows) + `download-artifact` v7→v8. Cherry-picked (authorship preserved). |
| AI finding — changelog link | `[Unreleased]` compare base `v0.8.3` → `v0.10.0`. |
| Changelog link hygiene | Backfilled the 10 missing `[0.8.8]`–`[0.10.0]` link-reference definitions (were rendering as literal text); each compares from the prior heading's tag (all tags verified). |
| AI findings — `build-device-map.ts` (**#44**) | Cherry-picked both Copilot Autofix commits; `device-map.tsv` regenerated so `make device-map-check` stays green. |
| PR review-bot instruction | New `.github/instructions/pr-review-bots.instructions.md` (registered in `CLAUDE.md`): how Copilot & CodeRabbit reviews differ from a `gh` POV, and that wrapping a PR means addressing findings **and** resolving the inline threads. |
| `.coderabbit.yaml` | Adopt the credit-conserving staged-review policy from centrs/quickchr (ready-for-review only, no per-commit incremental, ignore dependabot, terse tone), with rosetta path filters. |

## Repo settings changed alongside this PR (not files)

- **`main` branch protection enabled:** required checks (`test`, both CodeQL `Analyze`) + **required conversation resolution**, `enforce_admins: false` (admin override via the merge button or `gh`), no required approval count. This PR is itself now gated by it — see the `BLOCKED` merge state until its review threads are resolved.
- **CodeQL alerts #40 / #41** (`js/http-to-file-access`) **dismissed** as won't-fix: intended HTML cache writes in dev-time extraction tooling, not in the shipped `/app` runtime.

## Verification
- `bun tsc --noEmit`, `biome check`, `bun run src/build-device-map.ts --check` (no drift), `bun test ./src/release.test.ts` (128 pass), `cspell` + `markdownlint` on changed docs — all clean.

No CHANGELOG `[Unreleased]` entry: all items are CI-hygiene / refactor / meta per `changelog-discipline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)