### PR TITLE
Guard extractor entrypoints with import.meta.main

### DIFF
--- a/.github/instructions/extractor-import-side-effects.instructions.md
+++ b/.github/instructions/extractor-import-side-effects.instructions.md
@@ -1,11 +1,36 @@
 ---
-description: "Extractor tests must not open the real DB at import time. Use the safe DB_PATH + dynamic-import pattern for at-risk entrypoints."
+description: "Every extractor entrypoint must run its side effects only under `import.meta.main`. Extractor tests must not open the real DB at import time either."
 applyTo: "src/extract-*.ts, src/extract-*.test.ts"
 ---
 # Extractor import side effects
 
-Some extractor entrypoints still import `db.ts` at module evaluation time. For those files:
+There are two separate hazards here, and both must be closed for every `src/extract-*.ts`
+file (audited 2026-07-14, issue #19):
 
-- In tests, set `process.env.DB_PATH = ':memory:'` before importing the extractor.
-- Use dynamic `await import(...)` so Bun does not hoist the real-DB import before the env var assignment.
-- Prefer moving new extractors toward the safe pattern where importing the module does not touch the DB until `main()` runs.
+1. **No unguarded execution at module scope.** Every extractor's side-effecting logic
+   (DB writes, file/network reads, subprocess spawns) must live inside a `main()` function
+   called only under `if (import.meta.main) { ... }`. Pure helpers, type declarations, and
+   argument-shape parsing that has no I/O may stay at module scope. Without this guard,
+   merely `import`-ing the file — e.g. a future test reusing a parser helper — runs the
+   entire pipeline unconditionally. This was the actual gap found in the 2026-07-14 audit:
+   `extract-commands.ts`, `extract-devices.ts`, `extract-properties.ts`, and
+   `extract-all-versions.ts` had no `import.meta.main` guard at all. All extractors now
+   have one.
+
+2. **Top-level `db.ts` import still opens a connection.** `db.ts` does
+   `export const db = new sqlite(DB_PATH)` at module scope, so any extractor that does
+   `import { db, initDb } from "./db.ts"` at the top of the file opens a DB connection
+   the moment it's imported — even with the `import.meta.main` guard in place, since the
+   guard only defers *execution*, not the import itself. Most extractors keep this
+   top-level import (it's harmless as long as `DB_PATH` is set correctly before import).
+   For tests, that means:
+   - Set `process.env.DB_PATH = ':memory:'` before importing the extractor.
+   - Use dynamic `await import(...)` so Bun does not hoist the real-DB import before the
+     env var assignment.
+   - `extract-schema.ts` and `extract-test-results.ts` go further and dynamic-import
+     `db.ts` itself lazily inside `main()`, so importing them touches no DB at all — that's
+     the strictest form and is preferred for new extractors, but not required retroactively.
+
+`src/query.test.ts` carries a singleton guard (`V-db-wipe-guard` in `VALIDATION.md`) that
+fails loudly if any test file leaves the `db` singleton pointed at a non-`:memory:` path —
+treat a failure there as a real regression in one of the two patterns above, not test flakiness.

--- a/.github/instructions/extractor-import-side-effects.instructions.md
+++ b/.github/instructions/extractor-import-side-effects.instructions.md
@@ -1,11 +1,13 @@
 ---
-description: "Every extractor entrypoint must run its side effects only under `import.meta.main`. Extractor tests must not open the real DB at import time either."
+description: "Every extractor entrypoint must run its side effects only under `import.meta.main`. Top-level `db.ts` imports still open a real DB connection, so tests must import extractors safely."
 applyTo: "src/extract-*.ts, src/extract-*.test.ts"
 ---
 # Extractor import side effects
 
-There are two separate hazards here, and both must be closed for every `src/extract-*.ts`
-file (audited 2026-07-14, issue #19):
+There are two separate hazards here. Hazard 1 must be closed for every `src/extract-*.ts`
+file — and now is (audited 2026-07-14, issue #19). Hazard 2 is not closed for most
+extractors and isn't required to be; it's mitigated in tests by the import pattern
+described below.
 
 1. **No unguarded execution at module scope.** Every extractor's side-effecting logic
    (DB writes, file/network reads, subprocess spawns) must live inside a `main()` function
@@ -22,7 +24,10 @@ file (audited 2026-07-14, issue #19):
    `import { db, initDb } from "./db.ts"` at the top of the file opens a DB connection
    the moment it's imported — even with the `import.meta.main` guard in place, since the
    guard only defers *execution*, not the import itself. Most extractors keep this
-   top-level import (it's harmless as long as `DB_PATH` is set correctly before import).
+   top-level import; it opens the real on-disk DB unless the importer set `DB_PATH` first.
+   That's correct for normal CLI use (a real DB is exactly what you want), but it's a trap
+   for any test or script that imports the module without first setting `DB_PATH`. This is
+   not itself a bug to fix — it's the reason the test-import discipline below exists.
    For tests, that means:
    - Set `process.env.DB_PATH = ':memory:'` before importing the extractor.
    - Use dynamic `await import(...)` so Bun does not hoist the real-DB import before the

--- a/src/extract-all-versions.ts
+++ b/src/extract-all-versions.ts
@@ -129,81 +129,90 @@ function discoverLocalVersions(docsDir: string): VersionInfo[] {
     .sort((a, b) => compareVersions(a.version, b.version));
 }
 
-const localMode = SOURCE && !isHttpUrl(SOURCE);
+async function main() {
+  const localMode = SOURCE && !isHttpUrl(SOURCE);
 
-const versions = localMode
-  ? discoverLocalVersions(resolve(SOURCE))
-  : await discoverRemoteVersions();
+  const versions = localMode
+    ? discoverLocalVersions(resolve(SOURCE))
+    : await discoverRemoteVersions();
 
-console.log(
-  `Found ${versions.length} RouterOS versions${localMode ? ` in ${resolve(SOURCE)}` : " from restraml GitHub"}`,
-);
+  console.log(
+    `Found ${versions.length} RouterOS versions${localMode ? ` in ${resolve(SOURCE)}` : " from restraml GitHub"}`,
+  );
 
-if (versions.length === 0) {
-  throw new Error(`No inspect.json files found${localMode ? ` in ${resolve(SOURCE)}` : " from restraml GitHub"}`);
-}
+  if (versions.length === 0) {
+    throw new Error(`No inspect.json files found${localMode ? ` in ${resolve(SOURCE)}` : " from restraml GitHub"}`);
+  }
 
-// Determine the latest stable version for primary extraction
-const latestStable = [...versions].filter((v) => v.channel === "stable").pop();
-const latest = latestStable || versions[versions.length - 1];
-console.log(`Latest stable: ${latest?.version ?? "none"}`);
+  // Determine the latest stable version for primary extraction
+  const latestStable = [...versions].filter((v) => v.channel === "stable").pop();
+  const latest = latestStable || versions[versions.length - 1];
+  console.log(`Latest stable: ${latest?.version ?? "none"}`);
 
-// Run extraction for each version
-// For versions with deep-inspect: use extract-schema.ts (multi-arch, completion data)
-// For versions without: fall back to extract-commands.ts (legacy)
-// Primary version (latest stable) rebuilds the main tables; others accumulate only.
+  // Run extraction for each version
+  // For versions with deep-inspect: use extract-schema.ts (multi-arch, completion data)
+  // For versions without: fall back to extract-commands.ts (legacy)
+  // Primary version (latest stable) rebuilds the main tables; others accumulate only.
 
-const extractSchemaCmd = resolve(import.meta.dir, "extract-schema.ts");
-const extractCommandsCmd = resolve(import.meta.dir, "extract-commands.ts");
+  const extractSchemaCmd = resolve(import.meta.dir, "extract-schema.ts");
+  const extractCommandsCmd = resolve(import.meta.dir, "extract-commands.ts");
 
-const deepCount = versions.filter((v) => v.hasDeepInspect).length;
-const legacyCount = versions.length - deepCount;
-console.log(`Deep-inspect versions: ${deepCount}, legacy inspect.json: ${legacyCount}`);
+  const deepCount = versions.filter((v) => v.hasDeepInspect).length;
+  const legacyCount = versions.length - deepCount;
+  console.log(`Deep-inspect versions: ${deepCount}, legacy inspect.json: ${legacyCount}`);
 
-let extracted = 0;
-for (const v of versions) {
-  const isPrimary = v === latest;
-  const flags = [
-    `--version=${v.version}`,
-    `--channel=${v.channel}`,
-    ...(v.hasExtra ? ["--extra"] : []),
-    ...(isPrimary ? [] : ["--accumulate"]),
-  ];
+  let extracted = 0;
+  for (const v of versions) {
+    const isPrimary = v === latest;
+    const flags = [
+      `--version=${v.version}`,
+      `--channel=${v.channel}`,
+      ...(v.hasExtra ? ["--extra"] : []),
+      ...(isPrimary ? [] : ["--accumulate"]),
+    ];
+
+    console.log(`\n${"=".repeat(60)}`);
+
+    let proc: ReturnType<typeof Bun.spawnSync>;
+
+    if (v.hasDeepInspect) {
+      // Use extract-schema.ts with both arch files
+      const schemaFlags = [
+        ...(v.deepX86 ? [`--x86=${v.deepX86}`] : []),
+        ...(v.deepArm64 ? [`--arm64=${v.deepArm64}`] : []),
+        ...flags,
+      ];
+      console.log(`${isPrimary ? "PRIMARY" : "accumulate"}: ${v.version} (${v.channel}) [deep-inspect]`);
+
+      proc = Bun.spawnSync(["bun", "run", extractSchemaCmd, ...schemaFlags], {
+        cwd: resolve(import.meta.dir, ".."),
+        stdio: ["inherit", "inherit", "inherit"],
+      });
+    } else {
+      // Legacy fallback: use extract-commands.ts
+      console.log(`${isPrimary ? "PRIMARY" : "accumulate"}: ${v.version} (${v.channel}) [legacy inspect.json]`);
+
+      proc = Bun.spawnSync(["bun", "run", extractCommandsCmd, v.inspectPath, ...flags], {
+        cwd: resolve(import.meta.dir, ".."),
+        stdio: ["inherit", "inherit", "inherit"],
+      });
+    }
+
+    if (proc.exitCode !== 0) {
+      console.error(`FAILED: ${v.version} (exit ${proc.exitCode})`);
+      continue;
+    }
+    extracted++;
+  }
 
   console.log(`\n${"=".repeat(60)}`);
-
-  let proc: ReturnType<typeof Bun.spawnSync>;
-
-  if (v.hasDeepInspect) {
-    // Use extract-schema.ts with both arch files
-    const schemaFlags = [
-      ...(v.deepX86 ? [`--x86=${v.deepX86}`] : []),
-      ...(v.deepArm64 ? [`--arm64=${v.deepArm64}`] : []),
-      ...flags,
-    ];
-    console.log(`${isPrimary ? "PRIMARY" : "accumulate"}: ${v.version} (${v.channel}) [deep-inspect]`);
-
-    proc = Bun.spawnSync(["bun", "run", extractSchemaCmd, ...schemaFlags], {
-      cwd: resolve(import.meta.dir, ".."),
-      stdio: ["inherit", "inherit", "inherit"],
-    });
-  } else {
-    // Legacy fallback: use extract-commands.ts
-    console.log(`${isPrimary ? "PRIMARY" : "accumulate"}: ${v.version} (${v.channel}) [legacy inspect.json]`);
-
-    proc = Bun.spawnSync(["bun", "run", extractCommandsCmd, v.inspectPath, ...flags], {
-      cwd: resolve(import.meta.dir, ".."),
-      stdio: ["inherit", "inherit", "inherit"],
-    });
-  }
-
-  if (proc.exitCode !== 0) {
-    console.error(`FAILED: ${v.version} (exit ${proc.exitCode})`);
-    continue;
-  }
-  extracted++;
+  console.log(`Done. Extracted ${extracted}/${versions.length} versions.`);
+  console.log(`Primary version: ${latest?.version ?? "none"}`);
 }
 
-console.log(`\n${"=".repeat(60)}`);
-console.log(`Done. Extracted ${extracted}/${versions.length} versions.`);
-console.log(`Primary version: ${latest?.version ?? "none"}`);
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("Fatal:", e);
+    process.exit(1);
+  });
+}

--- a/src/extract-commands.ts
+++ b/src/extract-commands.ts
@@ -24,21 +24,6 @@
 import { db, initDb } from "./db.ts";
 import { loadJson, RESTRAML_PAGES_URL } from "./restraml.ts";
 
-// Parse flags
-const cliArgs = process.argv.slice(2);
-const accumulate = cliArgs.includes("--accumulate");
-const extraPackages = cliArgs.includes("--extra");
-const positional = cliArgs.filter((a) => !a.startsWith("--"));
-const flagArgs = Object.fromEntries(
-  cliArgs.filter((a) => a.startsWith("--") && a.includes("=")).map((a) => {
-    const [k, ...v] = a.slice(2).split("=");
-    return [k, v.join("=")];
-  }),
-);
-
-const DEFAULT_INSPECT_URL = `${RESTRAML_PAGES_URL}/7.22.1/extra/inspect.json`;
-const INSPECT_SOURCE = positional[0] || DEFAULT_INSPECT_URL;
-
 function deriveArch(filepath: string, flag: string | undefined): "x86" | "arm64" {
   if (flag === "x86" || flag === "arm64") return flag;
   if (/deep-inspect\.arm64\b/.test(filepath)) return "arm64";
@@ -59,14 +44,6 @@ function deriveChannel(version: string): string {
   return "stable";
 }
 
-const version = flagArgs.version || deriveVersion(INSPECT_SOURCE);
-const channel = flagArgs.channel || deriveChannel(version);
-const arch = deriveArch(INSPECT_SOURCE, flagArgs.arch);
-
-console.log(`Loading inspect.json from ${INSPECT_SOURCE}...`);
-console.log(`Version: ${version}, Channel: ${channel}, Arch: ${arch}, Extra: ${extraPackages}, Accumulate: ${accumulate}`);
-const inspectData = await loadJson<Record<string, unknown>>(INSPECT_SOURCE);
-
 // deep-inspect.json files carry a `_meta` envelope; vanilla inspect.json does not.
 interface DeepInspectMeta {
   version?: string;
@@ -74,15 +51,6 @@ interface DeepInspectMeta {
   crashPathsTested?: string[];
   crashPathsCrashed?: string[];
   completionStats?: Record<string, unknown>;
-}
-const meta = (inspectData._meta && typeof inspectData._meta === "object")
-  ? (inspectData._meta as DeepInspectMeta)
-  : null;
-if (meta) {
-  console.log(`  _meta.version=${meta.version} generatedAt=${meta.generatedAt}`);
-  if (meta.completionStats) {
-    console.log(`  completionStats=${JSON.stringify(meta.completionStats)}`);
-  }
 }
 
 interface CommandRow {
@@ -93,9 +61,7 @@ interface CommandRow {
   description: string | null;
 }
 
-const rows: CommandRow[] = [];
-
-function walk(obj: Record<string, unknown>, parentPath: string) {
+function walk(obj: Record<string, unknown>, parentPath: string, rows: CommandRow[]) {
   for (const [key, value] of Object.entries(obj)) {
     if (key === "_type" || key === "desc" || key === "_meta") continue;
     if (typeof value !== "object" || value === null) continue;
@@ -120,101 +86,144 @@ function walk(obj: Record<string, unknown>, parentPath: string) {
 
     // Recurse into children (dirs, paths, and cmds have children)
     if (normalizedType === "dir" || normalizedType === "cmd") {
-      walk(node, currentPath);
+      walk(node, currentPath, rows);
     }
   }
 }
 
-walk(inspectData, "");
+async function main() {
+  // Parse flags
+  const cliArgs = process.argv.slice(2);
+  const accumulate = cliArgs.includes("--accumulate");
+  const extraPackages = cliArgs.includes("--extra");
+  const positional = cliArgs.filter((a) => !a.startsWith("--"));
+  const flagArgs = Object.fromEntries(
+    cliArgs.filter((a) => a.startsWith("--") && a.includes("=")).map((a) => {
+      const [k, ...v] = a.slice(2).split("=");
+      return [k, v.join("=")];
+    }),
+  );
 
-console.log(`Parsed ${rows.length} command tree entries`);
-const dirs = rows.filter((r) => r.type === "dir").length;
-const cmds = rows.filter((r) => r.type === "cmd").length;
-const args = rows.filter((r) => r.type === "arg").length;
-console.log(`  dirs: ${dirs}, cmds: ${cmds}, args: ${args}`);
+  const DEFAULT_INSPECT_URL = `${RESTRAML_PAGES_URL}/7.22.1/extra/inspect.json`;
+  const INSPECT_SOURCE = positional[0] || DEFAULT_INSPECT_URL;
 
-// Initialize DB and insert
-initDb();
+  const version = flagArgs.version || deriveVersion(INSPECT_SOURCE);
+  const channel = flagArgs.channel || deriveChannel(version);
+  const arch = deriveArch(INSPECT_SOURCE, flagArgs.arch);
 
-// Register this version (per-arch row). _meta fields are populated when the
-// source is a deep-inspect.json; legacy inspect.json leaves them NULL.
-db.run(
-  `INSERT OR REPLACE INTO ros_versions
-   (version, arch, channel, extra_packages, extracted_at,
-    generated_at, crash_paths_tested, crash_paths_crashed, completion_stats, source_url)
-   VALUES (?, ?, ?, ?, datetime('now'), ?, ?, ?, ?, ?)`,
-  [
-    version,
-    arch,
-    channel,
-    extraPackages ? 1 : 0,
-    meta?.generatedAt ?? null,
-    meta?.crashPathsTested ? JSON.stringify(meta.crashPathsTested) : null,
-    meta?.crashPathsCrashed ? JSON.stringify(meta.crashPathsCrashed) : null,
-    meta?.completionStats ? JSON.stringify(meta.completionStats) : null,
-    INSPECT_SOURCE,
-  ],
-);
+  console.log(`Loading inspect.json from ${INSPECT_SOURCE}...`);
+  console.log(`Version: ${version}, Channel: ${channel}, Arch: ${arch}, Extra: ${extraPackages}, Accumulate: ${accumulate}`);
+  const inspectData = await loadJson<Record<string, unknown>>(INSPECT_SOURCE);
 
-if (!accumulate) {
-  // Primary mode: replace commands table entirely, set ros_version
-  db.run("DELETE FROM commands;");
+  const meta = (inspectData._meta && typeof inspectData._meta === "object")
+    ? (inspectData._meta as DeepInspectMeta)
+    : null;
+  if (meta) {
+    console.log(`  _meta.version=${meta.version} generatedAt=${meta.generatedAt}`);
+    if (meta.completionStats) {
+      console.log(`  completionStats=${JSON.stringify(meta.completionStats)}`);
+    }
+  }
 
-  const insert = db.prepare(`
-    INSERT OR IGNORE INTO commands (path, name, type, parent_path, description, ros_version)
-    VALUES (?, ?, ?, ?, ?, ?)
+  const rows: CommandRow[] = [];
+  walk(inspectData, "", rows);
+
+  console.log(`Parsed ${rows.length} command tree entries`);
+  const dirs = rows.filter((r) => r.type === "dir").length;
+  const cmds = rows.filter((r) => r.type === "cmd").length;
+  const args = rows.filter((r) => r.type === "arg").length;
+  console.log(`  dirs: ${dirs}, cmds: ${cmds}, args: ${args}`);
+
+  // Initialize DB and insert
+  initDb();
+
+  // Register this version (per-arch row). _meta fields are populated when the
+  // source is a deep-inspect.json; legacy inspect.json leaves them NULL.
+  db.run(
+    `INSERT OR REPLACE INTO ros_versions
+     (version, arch, channel, extra_packages, extracted_at,
+      generated_at, crash_paths_tested, crash_paths_crashed, completion_stats, source_url)
+     VALUES (?, ?, ?, ?, datetime('now'), ?, ?, ?, ?, ?)`,
+    [
+      version,
+      arch,
+      channel,
+      extraPackages ? 1 : 0,
+      meta?.generatedAt ?? null,
+      meta?.crashPathsTested ? JSON.stringify(meta.crashPathsTested) : null,
+      meta?.crashPathsCrashed ? JSON.stringify(meta.crashPathsCrashed) : null,
+      meta?.completionStats ? JSON.stringify(meta.completionStats) : null,
+      INSPECT_SOURCE,
+    ],
+  );
+
+  if (!accumulate) {
+    // Primary mode: replace commands table entirely, set ros_version
+    db.run("DELETE FROM commands;");
+
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO commands (path, name, type, parent_path, description, ros_version)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+
+    const insertCommands = db.transaction(() => {
+      for (const r of rows) {
+        insert.run(r.path, r.name, r.type, r.parentPath, r.description, version);
+      }
+    });
+    insertCommands();
+
+    const total = (db.prepare("SELECT COUNT(*) as c FROM commands").get() as { c: number }).c;
+    console.log(`\nInserted ${total} commands into database (primary: ${version})`);
+  }
+
+  // Always populate command_versions for this version
+  db.run("DELETE FROM command_versions WHERE ros_version = ?", [version]);
+
+  const insertVersion = db.prepare(`
+    INSERT OR IGNORE INTO command_versions (command_path, ros_version)
+    VALUES (?, ?)
   `);
 
-  const insertCommands = db.transaction(() => {
+  const insertVersions = db.transaction(() => {
     for (const r of rows) {
-      insert.run(r.path, r.name, r.type, r.parentPath, r.description, version);
+      insertVersion.run(r.path, version);
     }
   });
-  insertCommands();
+  insertVersions();
 
-  const total = (db.prepare("SELECT COUNT(*) as c FROM commands").get() as { c: number }).c;
-  console.log(`\nInserted ${total} commands into database (primary: ${version})`);
+  const versionCount = (
+    db.prepare("SELECT COUNT(*) as c FROM command_versions WHERE ros_version = ?").get(version) as { c: number }
+  ).c;
+  console.log(`Recorded ${versionCount} command_versions entries for ${version}`);
+
+  const totalVersions = (db.prepare("SELECT COUNT(DISTINCT ros_version) as c FROM command_versions").get() as { c: number }).c;
+  console.log(`Total versions tracked: ${totalVersions}`);
+
+  if (!accumulate) {
+    // Sample: show the /ip/firewall subtree
+    console.log("\nSample: /ip/firewall children:");
+    const children = db
+      .prepare("SELECT path, type FROM commands WHERE parent_path = '/ip/firewall' ORDER BY path")
+      .all() as Array<{ path: string; type: string }>;
+    for (const c of children) {
+      console.log(`  ${c.type.padEnd(4)} ${c.path}`);
+    }
+
+    // Show top-level dirs
+    console.log("\nTop-level directories:");
+    const topLevel = db
+      .prepare("SELECT path FROM commands WHERE parent_path = '' AND type = 'dir' ORDER BY path")
+      .all() as Array<{ path: string }>;
+    for (const t of topLevel) {
+      console.log(`  ${t.path}`);
+    }
+  }
 }
 
-// Always populate command_versions for this version
-db.run("DELETE FROM command_versions WHERE ros_version = ?", [version]);
-
-const insertVersion = db.prepare(`
-  INSERT OR IGNORE INTO command_versions (command_path, ros_version)
-  VALUES (?, ?)
-`);
-
-const insertVersions = db.transaction(() => {
-  for (const r of rows) {
-    insertVersion.run(r.path, version);
-  }
-});
-insertVersions();
-
-const versionCount = (
-  db.prepare("SELECT COUNT(*) as c FROM command_versions WHERE ros_version = ?").get(version) as { c: number }
-).c;
-console.log(`Recorded ${versionCount} command_versions entries for ${version}`);
-
-const totalVersions = (db.prepare("SELECT COUNT(DISTINCT ros_version) as c FROM command_versions").get() as { c: number }).c;
-console.log(`Total versions tracked: ${totalVersions}`);
-
-if (!accumulate) {
-  // Sample: show the /ip/firewall subtree
-  console.log("\nSample: /ip/firewall children:");
-  const children = db
-    .prepare("SELECT path, type FROM commands WHERE parent_path = '/ip/firewall' ORDER BY path")
-    .all() as Array<{ path: string; type: string }>;
-  for (const c of children) {
-    console.log(`  ${c.type.padEnd(4)} ${c.path}`);
-  }
-
-  // Show top-level dirs
-  console.log("\nTop-level directories:");
-  const topLevel = db
-    .prepare("SELECT path FROM commands WHERE parent_path = '' AND type = 'dir' ORDER BY path")
-    .all() as Array<{ path: string }>;
-  for (const t of topLevel) {
-    console.log(`  ${t.path}`);
-  }
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("Fatal:", e);
+    process.exit(1);
+  });
 }

--- a/src/extract-devices.ts
+++ b/src/extract-devices.ts
@@ -105,111 +105,117 @@ function parsePrice(value: string): number | null {
 
 // ── Main ──
 
-initDb();
+function main() {
+  initDb();
 
-const raw = readFileSync(csvPath, "utf-8");
-// Strip UTF-8 BOM
-const content = raw.replace(/^\ufeff/, "");
-const lines = content.split(/\r?\n/).filter((l) => l.trim());
+  const raw = readFileSync(csvPath, "utf-8");
+  // Strip UTF-8 BOM
+  const content = raw.replace(/^\ufeff/, "");
+  const lines = content.split(/\r?\n/).filter((l) => l.trim());
 
-if (lines.length < 2) {
-  console.error("CSV has no data rows");
-  process.exit(1);
+  if (lines.length < 2) {
+    console.error("CSV has no data rows");
+    process.exit(1);
+  }
+
+  // Skip header row
+  const dataLines = lines.slice(1);
+
+  // Idempotent: clear existing data (FTS triggers handle cleanup).
+  // device_test_results and hardware_catalog both FK into devices — wipe them first to
+  // avoid a FOREIGN KEY constraint failure on re-run over a populated DB. Re-extracting
+  // devices also invalidates hardware_catalog.device_id links (device ids are AUTOINCREMENT,
+  // not stable), so device_aliases is cleared too; extract-test-results and
+  // extract-hardware-catalog run later and repopulate their tables from scratch.
+  db.run("DELETE FROM device_test_results");
+  db.run("DELETE FROM device_aliases");
+  db.run("DELETE FROM hardware_catalog");
+  db.run("DELETE FROM devices");
+
+  const insert = db.prepare(`INSERT INTO devices (
+    product_name, product_code, architecture, cpu, cpu_cores, cpu_frequency,
+    license_level, operating_system, ram, ram_mb, storage, storage_mb,
+    dimensions, poe_in, poe_out, poe_out_ports, poe_in_voltage,
+    dc_inputs, dc_jack_voltage, max_power_w,
+    wireless_24_chains, antenna_24_dbi, wireless_5_chains, antenna_5_dbi,
+    eth_fast, eth_gigabit, eth_2500, usb_ports, combo_ports,
+    sfp_ports, sfp_plus_ports, eth_multigig, sim_slots,
+    memory_cards, usb_type, msrp_usd
+  ) VALUES (
+    ?, ?, ?, ?, ?, ?,
+    ?, ?, ?, ?, ?, ?,
+    ?, ?, ?, ?, ?,
+    ?, ?, ?,
+    ?, ?, ?, ?,
+    ?, ?, ?, ?, ?,
+    ?, ?, ?, ?,
+    ?, ?, ?
+  )`);
+
+  let inserted = 0;
+  let skipped = 0;
+
+  const insertAll = db.transaction(() => {
+    for (const line of dataLines) {
+      const f = parseCsvLine(line);
+      if (f.length < 34) {
+        skipped++;
+        continue;
+      }
+
+      const productName = normalizeSuperscripts(f[0].trim());
+      if (!productName) {
+        skipped++;
+        continue;
+      }
+
+      insert.run(
+        productName,
+        f[1].trim() || null,    // product_code
+        f[2].trim() || null,    // architecture
+        f[3].trim() || null,    // cpu
+        parseIntOrNull(f[4]),   // cpu_cores
+        f[5].trim() || null,    // cpu_frequency
+        parseIntOrNull(f[6]),   // license_level
+        f[7].trim() || null,    // operating_system
+        f[8].trim() || null,    // ram
+        parseSizeMb(f[8]),      // ram_mb
+        f[9].trim() || null,    // storage
+        parseSizeMb(f[9]),      // storage_mb
+        f[10].trim() || null,   // dimensions
+        f[11].trim() || null,   // poe_in
+        f[12].trim() || null,   // poe_out
+        f[13].trim() || null,   // poe_out_ports
+        f[14].trim() || null,   // poe_in_voltage
+        parseIntOrNull(f[15]),  // dc_inputs
+        f[16].trim() || null,   // dc_jack_voltage
+        parseWatts(f[17]),      // max_power_w
+        parseIntOrNull(f[18]),  // wireless_24_chains
+        parseFloatOrNull(f[19]),// antenna_24_dbi
+        parseIntOrNull(f[20]),  // wireless_5_chains
+        parseFloatOrNull(f[21]),// antenna_5_dbi
+        parseIntOrNull(f[22]),  // eth_fast
+        parseIntOrNull(f[23]),  // eth_gigabit
+        parseIntOrNull(f[24]),  // eth_2500
+        parseIntOrNull(f[25]),  // usb_ports
+        parseIntOrNull(f[26]),  // combo_ports
+        parseIntOrNull(f[27]),  // sfp_ports
+        parseIntOrNull(f[28]),  // sfp_plus_ports
+        parseIntOrNull(f[29]),  // eth_multigig
+        parseIntOrNull(f[30]),  // sim_slots
+        f[31].trim() || null,   // memory_cards
+        f[32].trim() || null,   // usb_type
+        parsePrice(f[33]),      // msrp_usd
+      );
+      inserted++;
+    }
+  });
+
+  insertAll();
+
+  console.log(`Devices: ${inserted} inserted, ${skipped} skipped from ${csvPath}`);
 }
 
-// Skip header row
-const dataLines = lines.slice(1);
-
-// Idempotent: clear existing data (FTS triggers handle cleanup).
-// device_test_results and hardware_catalog both FK into devices — wipe them first to
-// avoid a FOREIGN KEY constraint failure on re-run over a populated DB. Re-extracting
-// devices also invalidates hardware_catalog.device_id links (device ids are AUTOINCREMENT,
-// not stable), so device_aliases is cleared too; extract-test-results and
-// extract-hardware-catalog run later and repopulate their tables from scratch.
-db.run("DELETE FROM device_test_results");
-db.run("DELETE FROM device_aliases");
-db.run("DELETE FROM hardware_catalog");
-db.run("DELETE FROM devices");
-
-const insert = db.prepare(`INSERT INTO devices (
-  product_name, product_code, architecture, cpu, cpu_cores, cpu_frequency,
-  license_level, operating_system, ram, ram_mb, storage, storage_mb,
-  dimensions, poe_in, poe_out, poe_out_ports, poe_in_voltage,
-  dc_inputs, dc_jack_voltage, max_power_w,
-  wireless_24_chains, antenna_24_dbi, wireless_5_chains, antenna_5_dbi,
-  eth_fast, eth_gigabit, eth_2500, usb_ports, combo_ports,
-  sfp_ports, sfp_plus_ports, eth_multigig, sim_slots,
-  memory_cards, usb_type, msrp_usd
-) VALUES (
-  ?, ?, ?, ?, ?, ?,
-  ?, ?, ?, ?, ?, ?,
-  ?, ?, ?, ?, ?,
-  ?, ?, ?,
-  ?, ?, ?, ?,
-  ?, ?, ?, ?, ?,
-  ?, ?, ?, ?,
-  ?, ?, ?
-)`);
-
-let inserted = 0;
-let skipped = 0;
-
-const insertAll = db.transaction(() => {
-  for (const line of dataLines) {
-    const f = parseCsvLine(line);
-    if (f.length < 34) {
-      skipped++;
-      continue;
-    }
-
-    const productName = normalizeSuperscripts(f[0].trim());
-    if (!productName) {
-      skipped++;
-      continue;
-    }
-
-    insert.run(
-      productName,
-      f[1].trim() || null,    // product_code
-      f[2].trim() || null,    // architecture
-      f[3].trim() || null,    // cpu
-      parseIntOrNull(f[4]),   // cpu_cores
-      f[5].trim() || null,    // cpu_frequency
-      parseIntOrNull(f[6]),   // license_level
-      f[7].trim() || null,    // operating_system
-      f[8].trim() || null,    // ram
-      parseSizeMb(f[8]),      // ram_mb
-      f[9].trim() || null,    // storage
-      parseSizeMb(f[9]),      // storage_mb
-      f[10].trim() || null,   // dimensions
-      f[11].trim() || null,   // poe_in
-      f[12].trim() || null,   // poe_out
-      f[13].trim() || null,   // poe_out_ports
-      f[14].trim() || null,   // poe_in_voltage
-      parseIntOrNull(f[15]),  // dc_inputs
-      f[16].trim() || null,   // dc_jack_voltage
-      parseWatts(f[17]),      // max_power_w
-      parseIntOrNull(f[18]),  // wireless_24_chains
-      parseFloatOrNull(f[19]),// antenna_24_dbi
-      parseIntOrNull(f[20]),  // wireless_5_chains
-      parseFloatOrNull(f[21]),// antenna_5_dbi
-      parseIntOrNull(f[22]),  // eth_fast
-      parseIntOrNull(f[23]),  // eth_gigabit
-      parseIntOrNull(f[24]),  // eth_2500
-      parseIntOrNull(f[25]),  // usb_ports
-      parseIntOrNull(f[26]),  // combo_ports
-      parseIntOrNull(f[27]),  // sfp_ports
-      parseIntOrNull(f[28]),  // sfp_plus_ports
-      parseIntOrNull(f[29]),  // eth_multigig
-      parseIntOrNull(f[30]),  // sim_slots
-      f[31].trim() || null,   // memory_cards
-      f[32].trim() || null,   // usb_type
-      parsePrice(f[33]),      // msrp_usd
-    );
-    inserted++;
-  }
-});
-
-insertAll();
-
-console.log(`Devices: ${inserted} inserted, ${skipped} skipped from ${csvPath}`);
+if (import.meta.main) {
+  main();
+}

--- a/src/extract-properties.ts
+++ b/src/extract-properties.ts
@@ -158,77 +158,83 @@ function extractProperties(pageId: number, htmlFile: string): PropertyRow[] {
 
 // ---- Main ----
 
-console.log("Initializing database...");
-initDb();
+function main() {
+  console.log("Initializing database...");
+  initDb();
 
-// Clear existing properties for clean re-extraction
-db.run("DELETE FROM properties;");
-db.run("INSERT INTO properties_fts(properties_fts) VALUES('rebuild');");
+  // Clear existing properties for clean re-extraction
+  db.run("DELETE FROM properties;");
+  db.run("INSERT INTO properties_fts(properties_fts) VALUES('rebuild');");
 
-// Get all pages that have HTML files
-type PageRef = { id: number; html_file: string; title: string };
-const pages = db.prepare("SELECT id, html_file, title FROM pages").all() as PageRef[];
+  // Get all pages that have HTML files
+  type PageRef = { id: number; html_file: string; title: string };
+  const pages = db.prepare("SELECT id, html_file, title FROM pages").all() as PageRef[];
 
-const insert = db.prepare(`
-  INSERT OR IGNORE INTO properties
-    (page_id, name, type, default_val, description, section, sort_order)
-  VALUES (?, ?, ?, ?, ?, ?, ?)
-`);
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO properties
+      (page_id, name, type, default_val, description, section, sort_order)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
 
-let totalProperties = 0;
-let pagesWithProps = 0;
+  let totalProperties = 0;
+  let pagesWithProps = 0;
 
-const insertAll = db.transaction(() => {
-  for (const page of pages) {
-    const props = extractProperties(page.id, page.html_file);
-    if (props.length > 0) {
-      pagesWithProps++;
-      for (const p of props) {
-        insert.run(p.pageId, p.name, p.type, p.defaultVal, p.description, p.section, p.sortOrder);
-        totalProperties++;
+  const insertAll = db.transaction(() => {
+    for (const page of pages) {
+      const props = extractProperties(page.id, page.html_file);
+      if (props.length > 0) {
+        pagesWithProps++;
+        for (const p of props) {
+          insert.run(p.pageId, p.name, p.type, p.defaultVal, p.description, p.section, p.sortOrder);
+          totalProperties++;
+        }
       }
     }
+  });
+  insertAll();
+
+  const ftsCount = (db.prepare("SELECT COUNT(*) as c FROM properties_fts").get() as { c: number }).c;
+
+  console.log(`\nProperty extraction complete:`);
+  console.log(`  Properties extracted: ${totalProperties}`);
+  console.log(`  Pages with properties: ${pagesWithProps}`);
+  console.log(`  FTS index rows: ${ftsCount}`);
+
+  // Sample output
+  console.log(`\nSample properties from DHCP page:`);
+  const dhcpProps = db
+    .prepare(
+      `SELECT name, type, default_val, section
+       FROM properties
+       WHERE page_id = (SELECT id FROM pages WHERE title = 'DHCP')
+       ORDER BY sort_order LIMIT 10`,
+    )
+    .all() as Array<{ name: string; type: string; default_val: string; section: string }>;
+
+  for (const p of dhcpProps) {
+    console.log(`  ${p.name} (${p.type || "?"}) [default: ${p.default_val || "none"}] — ${p.section}`);
   }
-});
-insertAll();
 
-const ftsCount = (db.prepare("SELECT COUNT(*) as c FROM properties_fts").get() as { c: number }).c;
+  // Test FTS search
+  console.log(`\nSearch for "gateway":`);
+  const results = db
+    .prepare(
+      `SELECT p.name, p.type, p.default_val, pg.title as page_title, p.section,
+              snippet(properties_fts, 1, '>>>', '<<<', '...', 20) as excerpt
+       FROM properties_fts fts
+       JOIN properties p ON p.id = fts.rowid
+       JOIN pages pg ON pg.id = p.page_id
+       WHERE properties_fts MATCH 'gateway'
+       ORDER BY rank LIMIT 5`,
+    )
+    .all() as Array<{ name: string; type: string; default_val: string; page_title: string; section: string; excerpt: string }>;
 
-console.log(`\nProperty extraction complete:`);
-console.log(`  Properties extracted: ${totalProperties}`);
-console.log(`  Pages with properties: ${pagesWithProps}`);
-console.log(`  FTS index rows: ${ftsCount}`);
-
-// Sample output
-console.log(`\nSample properties from DHCP page:`);
-const dhcpProps = db
-  .prepare(
-    `SELECT name, type, default_val, section
-     FROM properties
-     WHERE page_id = (SELECT id FROM pages WHERE title = 'DHCP')
-     ORDER BY sort_order LIMIT 10`,
-  )
-  .all() as Array<{ name: string; type: string; default_val: string; section: string }>;
-
-for (const p of dhcpProps) {
-  console.log(`  ${p.name} (${p.type || "?"}) [default: ${p.default_val || "none"}] — ${p.section}`);
+  for (const r of results) {
+    console.log(`  ${r.name} [${r.page_title} / ${r.section}]`);
+    console.log(`    ${r.excerpt}`);
+  }
 }
 
-// Test FTS search
-console.log(`\nSearch for "gateway":`);
-const results = db
-  .prepare(
-    `SELECT p.name, p.type, p.default_val, pg.title as page_title, p.section,
-            snippet(properties_fts, 1, '>>>', '<<<', '...', 20) as excerpt
-     FROM properties_fts fts
-     JOIN properties p ON p.id = fts.rowid
-     JOIN pages pg ON pg.id = p.page_id
-     WHERE properties_fts MATCH 'gateway'
-     ORDER BY rank LIMIT 5`,
-  )
-  .all() as Array<{ name: string; type: string; default_val: string; page_title: string; section: string; excerpt: string }>;
-
-for (const r of results) {
-  console.log(`  ${r.name} [${r.page_title} / ${r.section}]`);
-  console.log(`    ${r.excerpt}`);
+if (import.meta.main) {
+  main();
 }


### PR DESCRIPTION
## Summary
- Re-audited every `src/extract-*.ts` (issue #19) and found the hazard is worse than originally scoped: 4 extractors (`extract-commands.ts`, `extract-devices.ts`, `extract-properties.ts`, `extract-all-versions.ts`) had **no `import.meta.main` guard at all** — their full pipelines (DB writes, network fetches, subprocess spawns) ran unconditionally the instant the module was `import`ed, not just when run via `bun run`.
- Wrapped each in a `main()` gated by `if (import.meta.main)`, matching the pattern already used by the other 8 extractors (`extract-changelogs.ts`, `extract-docusaurus.ts`, `extract-dude.ts`, `extract-hardware-catalog.ts`, `extract-html.ts`, `extract-schema.ts`, `extract-skills.ts`, `extract-test-results.ts`, `extract-videos.ts`).
- Rewrote `extractor-import-side-effects.instructions.md` to describe the real, audited three-tier state (unguarded execution vs. top-level `db.ts` import vs. fully lazy DB import) instead of the two-tier version it previously described.
- No behavior change: helper functions/types kept at module scope, only side-effecting code moved inside `main()`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 828 pass, 0 fail (unchanged from before)
- [x] `bunx @biomejs/biome check` on the 4 changed extractor files — clean
- [x] Smoke test: dynamically importing all 4 files with `DB_PATH=:memory:` now runs zero extraction logic (previously ran the full pipeline)
- [x] Smoke test: direct `bun run src/extract-commands.ts <fixture>` and `bun run src/extract-devices.ts <csv>` still produce identical output to before the change
- [x] Smoke test: `extract-properties.ts` and `extract-all-versions.ts` still execute and fail/succeed the same way when run directly

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extraction tools now run only when explicitly launched, preventing unintended database or file operations when imported.
  * Improved handling of version, command, device, and property extraction workflows.
  * Added clearer error handling and execution summaries for extraction tasks.
* **Documentation**
  * Updated development guidance with safer import, database, and testing practices for extraction modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->