### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/src/extract-properties.ts
+++ b/src/extract-properties.ts
@@ -164,7 +164,6 @@ function main() {
 
   // Clear existing properties for clean re-extraction
   db.run("DELETE FROM properties;");
-  db.run("INSERT INTO properties_fts(properties_fts) VALUES('rebuild');");
 
   // Get all pages that have HTML files
   type PageRef = { id: number; html_file: string; title: string };
@@ -192,6 +191,7 @@ function main() {
     }
   });
   insertAll();
+  db.run("INSERT INTO properties_fts(properties_fts) VALUES('rebuild');");
 
   const ftsCount = (db.prepare("SELECT COUNT(*) as c FROM properties_fts").get() as { c: number }).c;
 


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/tikoci/rosetta/security/quality/ai-findings)._

The FTS `rebuild` command is executed before any properties are inserted (the insertion happens later inside `insertAll()`). Rebuilding the FTS index at this point will result in an empty index. The rebuild should be moved to after `insertAll()` completes, so the FTS index reflects the newly inserted data.