### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/src/hardware-www-map.test.ts
+++ b/src/hardware-www-map.test.ts
@@ -45,6 +45,7 @@ describe("hardware-www-map loader", () => {
     expect(curatedWwwCodeForSlug("r11e-lr8")).toBe(undefined);
     expect(curatedWwwCodeForSlug("ltap-lr8-lte6-kit")).toBe(undefined);
     expect(curatedWwwCodes()).toContain("r11e_lr8g"); // still seeded for the fetch
+    expect(curatedWwwCodes()).not.toContain("r11e_lr8"); // no www_code on seed_only entry => contributes nothing
     // r11e-lr9 (non-G) has no kit collision, so it DOES force-attach (a real gap closure).
     expect(curatedWwwCodeForSlug("r11e-lr9")).toBe("r11e_lr9");
   });


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/tikoci/rosetta/security/quality/ai-findings)._

Line 47 asserts `curatedWwwCodes()` contains `"r11e_lr8g"` (the `seed_only` module's code), but there is no corresponding assertion that `curatedWwwCodes()` does NOT contain the code for a `seed_only` entry that has no `www_code` (e.g., `r11e-lr8`, which appears to have no `www_code` per `hardware-unmatched.tsv`). The test does not verify that `seed_only` entries without a `www_code` contribute nothing to `curatedWwwCodes()`.