### PR TITLE
Review of 4 ai-findings-autofix draft PRs: 2 applied, 2 flagged bogus, 1 completed

### DIFF
--- a/src/build-device-map.ts
+++ b/src/build-device-map.ts
@@ -194,7 +194,7 @@ for (const r of matrixRows) {
 
   usedExceptions.add(r.name);
   const hwUrl = autoHw || (exc.hardware_slug ? `${HW_BASE}/${exc.hardware_slug}` : "");
-  const wwwUrl = autoWww || (exc.www_code ? `${WWW_BASE}/${exc.www_code}` : "");
+  const wwwUrl = autoWww || (exc.www_code ? `${WWW_BASE}/${encodeURIComponent(exc.www_code)}` : "");
   const hasBothUrls = Boolean(hwUrl && wwwUrl);
   // A curated-alias row with both URLs resolved is fully mapped and needs no review;
   // every other class carries its own name into needs_review.

--- a/src/release.test.ts
+++ b/src/release.test.ts
@@ -21,6 +21,12 @@ function mustIndex(haystack: string, needle: string): number {
   return idx;
 }
 
+function getPhonyBlock(makefile: string): string {
+  const phonyStart = makefile.indexOf(".PHONY:");
+  const phonyEnd = makefile.indexOf("\n\n", phonyStart);
+  return makefile.slice(phonyStart, phonyEnd);
+}
+
 // ---------------------------------------------------------------------------
 // package.json health
 // ---------------------------------------------------------------------------
@@ -353,9 +359,7 @@ describe("Makefile", () => {
 
   test("extract-videos is in PHONY", () => {
     // PHONY uses line continuation; check block before first blank line after .PHONY
-    const phonyStart = makefile.indexOf(".PHONY:");
-    const phonyEnd = makefile.indexOf("\n\n", phonyStart);
-    const phonyBlock = makefile.slice(phonyStart, phonyEnd);
+    const phonyBlock = getPhonyBlock(makefile);
     expect(phonyBlock).toContain("extract-videos");
   });
 
@@ -376,9 +380,7 @@ describe("Makefile", () => {
   });
 
   test("extract-skills is in PHONY", () => {
-    const phonyStart = makefile.indexOf(".PHONY:");
-    const phonyEnd = makefile.indexOf("\n\n", phonyStart);
-    const phonyBlock = makefile.slice(phonyStart, phonyEnd);
+    const phonyBlock = getPhonyBlock(makefile);
     expect(phonyBlock).toContain("extract-skills");
   });
 
@@ -388,16 +390,12 @@ describe("Makefile", () => {
   });
 
   test("gc-versions is in PHONY", () => {
-    const phonyStart = makefile.indexOf(".PHONY:");
-    const phonyEnd = makefile.indexOf("\n\n", phonyStart);
-    const phonyBlock = makefile.slice(phonyStart, phonyEnd);
+    const phonyBlock = getPhonyBlock(makefile);
     expect(phonyBlock).toContain("gc-versions");
   });
 
   test("extract-dude is in PHONY", () => {
-    const phonyStart = makefile.indexOf(".PHONY:");
-    const phonyEnd = makefile.indexOf("\n\n", phonyStart);
-    const phonyBlock = makefile.slice(phonyStart, phonyEnd);
+    const phonyBlock = getPhonyBlock(makefile);
     expect(phonyBlock).toContain("extract-dude");
   });
 
@@ -423,9 +421,7 @@ describe("Makefile", () => {
   });
 
   test("extract-docusaurus is in PHONY", () => {
-    const phonyStart = makefile.indexOf(".PHONY:");
-    const phonyEnd = makefile.indexOf("\n\n", phonyStart);
-    const phonyBlock = makefile.slice(phonyStart, phonyEnd);
+    const phonyBlock = getPhonyBlock(makefile);
     expect(phonyBlock).toContain("extract-docusaurus");
   });
 

--- a/src/release.test.ts
+++ b/src/release.test.ts
@@ -22,8 +22,9 @@ function mustIndex(haystack: string, needle: string): number {
 }
 
 function getPhonyBlock(makefile: string): string {
-  const phonyStart = makefile.indexOf(".PHONY:");
-  const phonyEnd = makefile.indexOf("\n\n", phonyStart);
+  const phonyStart = mustIndex(makefile, ".PHONY:");
+  const blankLine = makefile.indexOf("\n\n", phonyStart);
+  const phonyEnd = blankLine === -1 ? makefile.length : blankLine;
   return makefile.slice(phonyStart, phonyEnd);
 }
 


### PR DESCRIPTION
## Summary

Reviewed the 4 draft PRs GitHub's code-quality "AI findings" opened (#82, #83, #84, #85). Each finding was independently verified against the actual code/data before deciding whether to apply it. Result: **2 real fixes applied, 1 fix completed (it was only half-done), 2 findings are bogus** (based on misreading the code/data).

### ✅ Applied — real, verified issues

**From #85** (finding 1 of 3 only): `src/build-device-map.ts` — the exception-path `www_url` (`exc.www_code`) was built without `encodeURIComponent`, while the auto-resolved path a few lines above does encode. Real inconsistency; fixed to match.

**From #84** (completed properly): `src/release.test.ts` — extracted the duplicated `.PHONY:` block-parsing logic into a `getPhonyBlock()` helper. **The original PR only fixed 1 of the 5 call sites it identified in its own description** (lines 356–358 only; left 379–381, 391–393, 397–399, 425–427 untouched) — I applied the helper to all 5.

### 🚩 Flagged bogus — do not merge as-is, recommend closing

**#82** (`src/extract-properties.ts` FTS rebuild ordering) — **false positive**. The finding assumes `INSERT INTO properties_fts(properties_fts) VALUES('rebuild')` running before `insertAll()` leaves the FTS index empty. But `properties_fts` is a `content=properties` external-content FTS5 table with `AFTER INSERT/DELETE/UPDATE` triggers (`db.ts:140-153`, `props_ai`/`props_ad`/`props_au`) that keep it in sync automatically, independent of `rebuild` placement. I reproduced this in isolation (`bun:sqlite`, seed→delete→rebuild-before-insert→insert) and confirmed the FTS count and MATCH results are correct either way — the triggers repopulate the index as `insertAll()` runs. Reordering is harmless but doesn't fix anything real; not worth the diff.

**#83** (`src/hardware-www-map.test.ts` new assertion) — **based on misreading the source data**. The PR body claims `r11e-lr8` (the seed_only entry) "has no www_code," and proposes asserting `curatedWwwCodes()` does **not** contain `"r11e_lr8"`. But `hardware-www-map.toml` line 62-65 shows `["r11e-lr8"]` **does** have `www_code = "r11e_lr8g"` (it shares the LR8G product page — see the note in the TOML). The string `"r11e_lr8"` (no trailing G) was never a real code anywhere in the map, so the proposed assertion is vacuously true and tests nothing — it looks like it's covering the "seed_only entry with no www_code" case but it isn't (no such case exists in the current data). Not worth adding a misleading test.

**#85, findings 2 & 3** (type-safety refactor of `unmatchedRows` from tuples to a typed object) — **false positive**. Claims `row[1]` is typed `unknown` and "will produce a TypeScript error." Verified: `bun tsc --noEmit -p .` (strict mode) passes with **zero errors** on `main` today, including this file. TS correctly infers `unmatchedRows: string[][]` from the array-literal return in `.map()` — there's no unknown-typed access here. Skipped; the underlying array-based code is fine as-is.

## Verification

- `bun run typecheck` — clean
- `bun run lint` (biome) — clean
- `bun test` — 828 pass / 0 fail (848 total incl. skip/todo)

## Next steps for you

- Close #82, #83 (bogus findings, no fix needed)
- Close #84, #85 (superseded by this PR — #84's fix was completed here; #85's finding 1 was applied here, findings 2/3 skipped as false positives)
- This PR is left as **draft** per your request — flip to ready when you've reviewed the bogus-finding reasoning above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated links for curated exceptions by properly encoding special characters in exception codes.

* **Tests**
  * Improved Makefile validation tests by consolidating repeated checks for declared build tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->