### PR TITLE
Brief B-0022 with a runtime DB census

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,7 +88,7 @@ Grounded research and decision notes. Open items are ongoing thinking; resolved 
 | B-0019 | Hardware overlay Phase 2: surfacing `hardware_catalog`/`device_aliases` in MCP/TUI — design done, [#39](https://github.com/tikoci/rosetta/issues/39) closed; build spawned as [#49](https://github.com/tikoci/rosetta/issues/49)/[#50](https://github.com/tikoci/rosetta/issues/50) | resolved |
 | B-0020 | 0.11 retrieval-quality audit | open |
 | B-0021 | Off-matrix nomenclature (2B) + `&`-module / derivative-part taxonomy (2C) — decision-support for [#70](https://github.com/tikoci/rosetta/issues/70) | open |
-| B-0022 | Runtime SQLite-only dataset exports for local audit and future static hosting — feasibility inventory plus local-first implementation lean | open |
+| B-0022 | Runtime SQLite-only dataset exports for local audit and future static hosting — feasibility inventory grounded on the CI artifact; schema/ETL findings spawned as [#95](https://github.com/tikoci/rosetta/issues/95) umbrella (`export-audit`), export itself not yet built | open |
 
 ## Done index
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,6 +88,7 @@ Grounded research and decision notes. Open items are ongoing thinking; resolved 
 | B-0019 | Hardware overlay Phase 2: surfacing `hardware_catalog`/`device_aliases` in MCP/TUI — design done, [#39](https://github.com/tikoci/rosetta/issues/39) closed; build spawned as [#49](https://github.com/tikoci/rosetta/issues/49)/[#50](https://github.com/tikoci/rosetta/issues/50) | resolved |
 | B-0020 | 0.11 retrieval-quality audit | open |
 | B-0021 | Off-matrix nomenclature (2B) + `&`-module / derivative-part taxonomy (2C) — decision-support for [#70](https://github.com/tikoci/rosetta/issues/70) | open |
+| B-0022 | Runtime SQLite-only dataset exports for local audit and future static hosting — feasibility inventory plus local-first implementation lean | open |
 
 ## Done index
 

--- a/briefings/B-0022-runtime-sqlite-dataset-exports.md
+++ b/briefings/B-0022-runtime-sqlite-dataset-exports.md
@@ -1,0 +1,181 @@
+---
+id: B-0022-runtime-sqlite-dataset-exports
+topic: Runtime SQLite-only dataset exports for local audit and future static hosting
+status: open
+related_tasks: []
+created: 2026-07-15
+last_revisited: 2026-07-15
+---
+
+# Question
+
+What useful, spreadsheet-friendly datasets can rosetta export from its **runtime SQLite database
+alone**, and what does attempting those exports reveal that the current schema or ETL does not retain?
+
+The proposed first surface is deliberately small:
+
+```sh
+bunx @tikoci/rosetta export /tmp/rosetta-datasets
+```
+
+It creates one directory containing a deterministic set of TSV files. There are no CI or GitHub Pages
+changes in this pass, and no flags for partial exports, formats, or other options. (`@tikoci/rosetta`,
+with a slash, is the canonical package name.)
+
+# Why this is worth doing
+
+This is not only another presentation surface. A DB-only export is a practical audit of the artifact
+rosetta actually ships:
+
+- Maintainers can import broad, flat views into Numbers, Excel, or another analysis tool and perform
+  manual queries without first writing SQL.
+- Every field that cannot be produced from the runtime DB identifies a schema/ETL blind spot rather
+  than being silently recovered from `matrix/`, transcript caches, assessment JSON, fetched Markdown,
+  or another repo-only input.
+- Page, section, table, word, row, and byte distributions can expose unbalanced retrieval units and
+  inform later MCP/TUI work such as `limit` behavior or first-class handling for unusually large or
+  structured pages.
+- A deterministic directory is a natural precursor to publishing release-scoped static datasets on
+  GitHub Pages, where `curl`, `fetch()`, `requests`, and `awk` can consume ETL results without speaking
+  SQLite, MCP, or the TUI.
+
+This complements B-0003's decision not to expose a general `run_sql` MCP tool. It is a bounded,
+read-only set of bulk datasets, not arbitrary SQL execution in an agent-facing request path.
+
+# Hard boundary: the shipped DB is the source
+
+At runtime, `export` may read only the database selected through rosetta's normal DB resolution. It may
+run SQL, derive counts, decode stored JSON, and do small deterministic transformations of values already
+stored in SQLite. It must not read project caches or source artifacts, inspect the git checkout, fetch a
+network source, or rerun an extractor.
+
+In particular, the first pass must not fall back to:
+
+- `matrix/**`, `device-map.tsv`, `hardware-unmatched.tsv`, or hardware assessment artifacts;
+- `transcripts/**` or `manual/pages/**`;
+- `inspect.json`, `deep-inspect.json`, or restraml's GitHub Pages output;
+- source Markdown/HTML outside `pages.text` / `sections.text`; or
+- live MikroTik or YouTube endpoints.
+
+An unavailable column should be omitted or explicitly documented as unavailable. Recovering it from a
+cache would defeat the audit.
+
+# What the current SQLite shape can support
+
+This is a feasibility inventory, not a final column contract. Names below are descriptive rather than
+normative, and `#`-style count ideas are written as machine-friendly `*_count` columns.
+
+| Candidate export | DB-only feasibility today | Current grounding and gaps |
+|---|---|---|
+| `changelog.tsv` | Ready | `changelogs` directly stores `version`, `is_breaking`, `category`, and `description` (plus `released` and source order). The requested `version`, `breaking`, `category`, `text` view is a direct query. |
+| `videos.tsv` | Mostly ready | `videos` stores title, upload date, YouTube ID/URL, and whether chapters exist. Joining `video_segments` provides segment/chapter counts plus transcript word and UTF-8 byte counts. The DB does **not** retain transcript provenance/type such as auto-generated vs. manual or language/track; `has_chapters` can only support a derived layout label such as `chaptered` vs. `full-video`. Full transcript text is already stored, so future per-video text/metadata directories remain DB-only feasible. |
+| `properties.tsv` | Mostly ready | `properties` joins to `pages` for page slug/`rosetta_id`, numeric page ID, title, and URL; `properties.section` records the nearest heading text. It does not FK directly to `sections.id` or store the exact `anchor_id`, so a guaranteed fragment URL requires a schema improvement (or a potentially ambiguous heading-text join when headings repeat). |
+| `devices-matrix.tsv` | Ready | `devices` contains the normalized product-matrix fields. The existing `rosetta://datasets/devices.csv` query is the obvious query/column source to reuse, changing only the serialization to TSV rather than rebuilding the view from matrix files. |
+| `devices-by-hardware-slug.tsv` | Mostly ready | `hardware_catalog.source_hardware_slug` can be the row key; `device_id IS NOT NULL` answers `has_matrix`; `devices` provides CPU/RAM fields; `specs_json` carries broad www specs including `Switch chip model` when present. A `/hardware` page's raw body and byte size are **not** stored in this catalog, so only stored-spec JSON bytes can be reported, not hardware-page bytes. |
+| `devices-by-www-slug.tsv` | Mostly ready | `hardware_catalog.source_www_code` supplies the www path token, with the same matrix/spec joins and an optional `/hardware` URL derived from `source_hardware_slug`. The DB retains normalized www specs, not the raw www page body, so raw page byte counts are unavailable. Rows without a www source naturally do not appear in this keyed view. |
+| `pages/<page-slug>/<fragment>.tsv` | Conditionally feasible | Current Docusaurus rows retain raw Markdown in `pages.text` and section Markdown in `sections.text`, so a small runtime parser can extract generic Markdown tables without touching a cache. Tables are not normalized in SQLite, however, and legacy Confluence rows do not have the same Markdown contract. Duplicate fragments/multiple tables under one heading need deterministic suffixes such as `--2`; unsupported MDX/HTML tables must be reported rather than guessed. |
+| `pages.tsv` | Mostly ready | Page and fragment rows can carry slug/`rosetta_id`, title, URL, stored word counts, and UTF-8 byte counts derived from `pages.text` / `sections.text`; page rows provide the rollup. Table counts and table-row counts depend on the same DB-resident Markdown parser above because the schema does not store generic tables. |
+| `commands-by-version.tsv` | Mostly ready | `command_versions`, `commands`, `schema_nodes`, `schema_node_presence`, and `ros_versions` support per-version path/type counts and provenance. RouterOS versions must use the existing numeric/beta/RC comparator, not SQL lexical order. `ros_versions` can indicate which x86/arm64 deep-inspect inputs existed, but `schema_node_presence` lacks an architecture column, so exact per-version, per-architecture node counts are not durably representable today. The meanings of `cmd_count`, `dir_count`, `path_count`, and `arg_count` also need one explicit definition each before becoming a contract. |
+| `callouts.tsv` | Conditionally feasible | `callouts` directly provides page, type, order, and text. It has no section/fragment FK. Current Docusaurus Markdown can be re-parsed from `pages.text` to recover heading context, but that duplicates extraction logic and does not give legacy rows the same guarantee. Persisting `section_id` or `anchor_id` during ETL would make page+fragment a direct, auditable export. |
+
+## Immediate schema/ETL audit findings
+
+The exercise already exposes four concrete storage questions worth keeping visible even if the initial
+export simply documents the gaps:
+
+1. Should transcript source metadata (track language and auto/manual provenance) be retained alongside
+   `videos` or `video_segments`?
+2. Should `properties` and `callouts` carry a direct `section_id`/fragment identity rather than only
+   heading text (properties) or no fragment context (callouts)?
+3. Should generic Markdown tables become normalized ETL data, or is re-parsing DB-resident Markdown at
+   export time intentionally sufficient? B-0007 independently identified the same generic-table
+   question for device-capability pages.
+4. Does command presence eventually need `(node, version, arch)` rather than `(node, version)` if
+   architecture-specific audit exports are a desired contract?
+
+Raw `/hardware` and www document byte counts are a different boundary: rosetta currently stores their
+catalog identity and normalized facts, not those source documents as page corpora. Adding byte counts
+would require deliberately retaining a body or source-size fact during ETL; an exporter cannot recreate
+them honestly from `specs_json`.
+
+# Strawman local directory
+
+The first implementation can keep a stable, unsurprising layout while the exact columns remain subject
+to a follow-up issue:
+
+```text
+rosetta-datasets/
+├── manifest.tsv
+├── changelog.tsv
+├── videos.tsv
+├── properties.tsv
+├── devices-matrix.tsv
+├── devices-by-hardware-slug.tsv
+├── devices-by-www-slug.tsv
+├── pages.tsv
+├── commands-by-version.tsv
+├── callouts.tsv
+└── pages/
+    └── <page-slug>/
+        ├── <fragment>.tsv
+        └── <fragment>--2.tsv
+```
+
+`manifest.tsv` should identify the rosetta/schema/release provenance available in `db_meta`, list each
+generated file and row count, and record intentionally unavailable datasets/fields. That makes a local
+directory self-describing and later gives a static release URL a lightweight inventory without making
+JSON a supported dataset format yet.
+
+For spreadsheet safety and reproducibility, the likely serialization contract is UTF-8, LF endings, a
+header row, stable row/column ordering, empty fields for SQL `NULL`, and CSV-style double-quote escaping
+using a tab delimiter. Counts should define their unit: UTF-8 bytes via `length(CAST(value AS BLOB))`,
+and a single shared word-count rule rather than subtly different SQL and TypeScript approximations.
+Raw slugs and fragments stay in columns even when filesystem-safe names must be sanitized.
+
+# High-level plan of attack
+
+1. **Turn this inventory into executable probes.** For every proposed column, write the SQL or small
+   derivation against a runtime DB and mark unavailable fields explicitly. Check both a current release
+   database and focused fixture DBs; do not use source artifacts to make a probe pass.
+2. **Settle the initial column glossary and filenames.** Define count semantics, video transcript-type
+   handling, command count categories, TSV escaping, path sanitization/collisions, and behavior when the
+   destination already exists. Keep this small enough for one no-flags command.
+3. **Build one reusable export core.** Add an `export <directory>` CLI dispatch before MCP startup,
+   reuse existing DB resolution/readiness and device CSV query logic, and share deterministic TSV/path
+   helpers across datasets.
+4. **Land normalized exports first.** Changelog, videos, properties, matrix devices, hardware/www
+   device pivots, page/section scalar metrics, command-version aggregates, and page-level callouts are
+   mostly SQL plus formatting and provide the quickest local audit value.
+5. **Add the DB-resident Markdown pass deliberately.** Reuse/generalize the existing table-row parser
+   patterns, test multiple tables under one fragment and malformed/unsupported tables, then use the same
+   parse result for per-table files and page/fragment table counts. Decide whether callout fragment
+   recovery belongs in this parser or should wait for an ETL FK.
+6. **Validate the directory as an artifact.** Assert stable reruns, row counts against direct SQL,
+   correct quoting in Numbers/Excel-like inputs, no reads outside the DB, and useful failure behavior
+   without leaving a partially convincing directory.
+7. **Only then consider publication.** A later issue can define release/version URL layout, Pages
+   deployment, retention, compression, caching, and large-scale JSON. None belongs in the initial local
+   pass.
+
+# Current lean
+
+Proceed with a local DB-only exporter, but treat it as an **artifact audit with honest omissions**, not a
+promise that every strawman column already exists. Start with the normalized TSVs and scalar metrics;
+include the generic Markdown-table pass only if it remains small and deterministic against the Markdown
+stored in SQLite. Do not add cache fallbacks to fill holes.
+
+Before implementation, promote the settled first-pass file/column contract to a GitHub issue and cite
+this briefing. Schema additions uncovered here should be separate, explicit follow-ups unless one is
+strictly required for a coherent initial export.
+
+# Open questions
+
+- Is `transcript_type` meant to describe provenance (automatic/manual/language) or output layout
+  (chaptered/full-video)? Only the latter is derivable today.
+- Should page table exports include only pipe-style Markdown tables, or also raw HTML/MDX tables
+  retained in page text?
+- For device `byte_count`, is the desired unit the unavailable raw source-page body, or the stored
+  normalized `specs_json` payload?
+- Should legacy Confluence DBs export a reduced, clearly identified dataset, or should generic page-table
+  exports require current Docusaurus provenance?
+- Is an existing non-empty destination an error, an atomic replacement, or an idempotent overwrite?

--- a/briefings/B-0022-runtime-sqlite-dataset-exports.md
+++ b/briefings/B-0022-runtime-sqlite-dataset-exports.md
@@ -2,7 +2,7 @@
 id: B-0022-runtime-sqlite-dataset-exports
 topic: Runtime SQLite-only dataset exports for local audit and future static hosting
 status: open
-related_tasks: []
+related_tasks: ["#90", "#91", "#92", "#93", "#94", "#95"]
 created: 2026-07-15
 last_revisited: 2026-07-15
 ---
@@ -51,10 +51,22 @@ rosetta actually ships:
 This complements B-0003's decision not to expose a general `run_sql` MCP tool. It is a bounded,
 read-only set of bulk datasets, not arbitrary SQL execution in an agent-facing request path.
 
-The audit premise has already paid for itself. Working through the export column by column surfaced
-three defects in shipped data that no current test or surface reports: 165 properties destroyed on
-insert, per-version command counts that silently reflect one architecture, and 501 properties whose
-recorded section cannot exist as a row. Those are findings about rosetta's data, not about file formats.
+## Why a surface rather than an audit script
+
+The obvious objection is that a throwaway `scripts/census.ts` would have produced the findings in #95
+without shipping anything. The counter is transparency, and it is the reason to prefer files:
+
+- A script with no durable intermediate output becomes a thing future agents "fix" until it stops
+  complaining, or a source of truth of its own that no one reviews. Files a human opens in Numbers
+  cannot quietly drift.
+- The export is deliberately an **independent surface**: it re-derives the DB's contents without going
+  through the query/classifier path, so it functions as a design audit of the core database rather than
+  a report from the code under test.
+- The findings it produced are exactly the kind that are hard to see from MCP interactions — a
+  `get_page(section=)` returning nothing, or a per-version count that quietly means one architecture.
+
+Both are true at once: `src/eval/db-census.ts` exists to re-check the #95 findings after fixes land,
+and it is not a substitute for the export.
 
 # Hard boundary: the shipped DB is the source
 
@@ -74,20 +86,27 @@ In particular, the first pass must not fall back to:
 An unavailable column should be omitted or explicitly documented as unavailable. Recovering it from a
 cache would defeat the audit.
 
-The target is the current Docusaurus-built runtime artifact. The exporter does not need a reduced
-compatibility mode for historical Confluence release databases.
+The target is the current Docusaurus-built runtime artifact. `extract-docusaurus.ts` deletes and rebuilds
+`pages`/`sections`/`properties`/`callouts` on every run, so prose sources do not mix and the exporter
+needs no reduced compatibility mode for historical Confluence release databases.
 
-The Confluence-contamination worry is settled and can stop being carried as a risk. `extract-docusaurus.ts`
-deletes and rebuilds `pages`/`sections`/`properties`/`callouts` on every run, and a fresh build yields
-365 pages all under `manual.mikrotik.com` with zero `help.mikrotik.com` rows. Prose sources do not mix.
+# Grounding
 
-There is a **developer-environment trap** worth stating plainly, because it invalidates casual grounding:
-the repo-root `ros-help.db` is not the artifact this briefing targets. It is the v0.10.0 **Confluence**
-corpus (321 pages, all `help.mikrotik.com`), it is held open by running MCP servers, and the in-session
-`routeros_*` MCP tools answer from it. Any census of pages, sections, properties, callouts, or tables
-must be run against a freshly built Docusaurus DB at a scratch `DB_PATH`, or it measures the wrong
-corpus. Product, video, changelog, and command tables do not come from Docusaurus prose and are the same
-in both.
+Every count in this briefing comes from the **CI-built release artifact v0.11.0-rc.97**
+(`~/.rosetta/ros-help.db`, schema v8, 363 Docusaurus pages, `source_commit` 6a7e800) — not a local
+rebuild. CI is the truer source of truth because it is what npm consumers receive, and because `export`
+is meant to follow the DB-based extract rather than a developer's working state.
+
+This matters more than it sounds: a local `--from-cache` rebuild yields 365 pages against CI's 363, and
+grounding against a stale repo-root DB produced a wrong conclusion during this pass (that
+`schema_nodes`/`schema_node_presence` ship empty — they ship with 41,967 nodes). Knowing which DB is
+under the question is a prerequisite for trusting any of this; #94 tracks making that legible.
+
+`src/eval/db-census.ts` re-derives every measurement below from a runtime DB alone:
+
+```sh
+DB_PATH=~/.rosetta/ros-help.db bun run src/eval/db-census.ts
+```
 
 # Working export families and current feasibility
 
@@ -95,9 +114,6 @@ This is a feasibility inventory, not a final filename or column contract. Direct
 generally retain their SQLite names: the correspondence makes each export easier to trace and acts as a
 loose column-name audit. Derived or joined values still need names chosen for clarity in the file where
 they appear; matching SQL mechanically is less important than accurately describing the value.
-
-Counts below come from a `--from-cache` Docusaurus build (365 pages, 2,931 sections, 4,410 properties,
-945 callouts) for prose, and from the current catalog/command/video tables for the rest.
 
 ## Changelog
 
@@ -110,244 +126,162 @@ export context shows a good reason to rename them.
 
 `videos.tsv` is mostly direct. `videos` stores title, upload date, YouTube ID/URL, duration, view/like
 counts, and whether chapters exist. Joining `video_segments` provides segment/chapter counts plus
-transcript word and UTF-8 byte counts. Every video has at least one segment (538 videos, 1,953 segments;
-232 chaptered, 306 without chapters carrying a single whole-video segment), so the join never drops a row.
-Full transcript text is also in the DB, so a later `videos/<video_id>/` detail directory could remain
-within the DB-only constraint.
+transcript word and UTF-8 byte counts. Every video has at least one segment (658 videos, 2,175 segments;
+videos without chapters carry a single whole-video segment), so the join never drops a row. Full
+transcript text is also in the DB, so a later video detail directory stays within the DB-only constraint.
 
-The schema does not yet retain transcript provenance such as automatic vs. author-provided. That is
-already tracked by [#21](https://github.com/tikoci/rosetta/issues/21), including the proposed
-`transcript_source` field and the harder question of how reliably it can be detected. It should not
-block this export: omit the field now, make the gap visible in the manifest, and add it when the DB can
-provide it.
+That detail directory should be keyed on a **filesystem-encoded video title**, not the YouTube ID — an
+ID forces a cross-reference to be legible, which defeats the point of browsing a directory. The raw ID
+and URL stay as columns in `videos.tsv`, and the encoded directory name should itself be a column so the
+match between row and directory is definitive rather than inferred.
+
+Transcript provenance (automatic vs. author-provided) is not retained; that is #21's scope. Omit the
+field, note it in the manifest, add it when the DB can provide it.
 
 ## Products
 
-The product data is better considered one family than a collection of unrelated `devices-*` files.
-`devices`, `hardware_catalog`, `device_aliases`, and `hardware_catalog.specs_json` collectively represent
-rosetta's product knowledge across the matrix, `/hardware`, and www product sources.
+The product data is one family, not a collection of unrelated `devices-*` files. `devices`,
+`hardware_catalog`, `device_aliases`, and `hardware_catalog.specs_json` collectively represent rosetta's
+product knowledge across the matrix, `/hardware`, and www product sources.
 
-Coverage is now measured rather than assumed. Of 255 `hardware_catalog` rows: 247 have `specs_json`, 242
-have a `/hardware` slug, 209 have a www code, and only 156 link to a matrix `devices` row. So roughly
-**39% of catalog products have no matrix backing** — a `products.tsv` keyed on the catalog is strictly
-richer than re-exporting `devices`, and the matrix-presence column is a real audit signal, not a
-formality.
+**The catalog is the product identity, not the matrix.** Of 255 `hardware_catalog` rows: 247 have
+`specs_json`, 242 have a `/hardware` slug, 224 have a www code, and only **156 link to a matrix `devices`
+row**. The matrix is a manually updated source that predates the three-source scheme, and `/hardware` can
+grow between builds without any deliberate action — so matrix-presence is a *coverage signal to audit*,
+not a gate on what counts as a product. The normalized three-source shape is the "new matrix"; keying
+`products.tsv` on `hardware_catalog.rosetta_device_id` is what makes the other 99 products visible at
+all.
 
-`specs_json` holds **142 distinct keys** with a steep coverage curve: a head of keys at 74–85%
-(`Product code`, `Suggested price`, `MTBF`, `Max power consumption`, `Storage type`/`size`, `CPU`,
-`CPU core count`, `Architecture`, `Size of RAM`, `RouterOS license`) and a long sparse tail. That head
-is the answer to "which specs belong in the summary" — it is a coverage cliff, not a judgement call.
+`specs_json` holds 142 distinct keys with a steep coverage curve: a head at 74–85% (`Product code`,
+`Suggested price`, `MTBF`, `Max power consumption`, `Storage type`/`size`, `CPU`, `CPU core count`,
+`Architecture`, `Size of RAM`, `RouterOS license`) and a long sparse tail. Alongside that head,
+`products.tsv` should carry the **accessory/switch-chip capability keys**, which are the interesting
+hardware differentiators even where coverage is lower:
 
-One shape problem the export must decide rather than inherit: `specs_json` **mixes provenance metadata
-into the spec namespace**. `_hardware_title` (98%), `_www_title` (85%), and `_www_tagline` (85%) are
-underscore-prefixed internal fields sitting alongside genuine product specs. A naive vertical expansion
-would present them to a spreadsheet user as if they were specs. Either the exporter filters the
-underscore prefix (and the convention becomes load-bearing), or ETL should separate them.
+| Key | Products |
+|---|---|
+| `10/100/1000 Ethernet ports` | 152 |
+| `Switch chip model` | 126 |
+| `Number of USB ports` | 76 |
+| `USB slot type` | 74 |
+| `SFP+ ports` | 40 |
+| `SFP ports` | 34 |
+| `MiniPCI-e slots` | 30 |
 
-Likely useful views to probe are:
+Plus a total `spec_count` per product, so a sparse row is visibly sparse rather than silently so.
 
-- **`products/products.tsv`** — one row per `hardware_catalog.rosetta_device_id`, including source
-  identities/slugs, display name/category/lifecycle, matrix presence and common matrix fields, alias
-  count, spec count, and the measured high-coverage spec head above. This is the closest DB-only
-  successor to the manually produced `hardware-www-matrix.csv`.
-- **`products/matrix.tsv`** — the normalized matrix-backed fields currently exposed as
-  `rosetta://datasets/devices.csv`. `exportDevicesCsv()` already exists and is the obvious query source
-  to reuse, changing only the serialization.
+That `specs_json` also carries `_hardware_title` (98%), `_www_title` (85%), and `_www_tagline` (85%)
+alongside genuine specs is fine — those are per-source titles, and seeing them next to the normalized
+name is itself an audit of how the three sources agree. The exporter should surface them, not filter them.
+
+Files:
+
+- **`products/products.tsv`** — one row per `rosetta_device_id`: source identities/slugs, display
+  name/category/lifecycle, matrix presence and common matrix fields, alias count, `spec_count`, the
+  high-coverage spec head, and the accessory/switch-chip keys above.
+- **`products/matrix.tsv`** — the matrix-backed fields already exposed as
+  `rosetta://datasets/devices.csv`. `exportDevicesCsv()` exists and is the query source to reuse,
+  changing only serialization.
 - **`products/<rosetta_device_id>/specs.tsv`** — a vertical `name`/`value` expansion of every stored
-  `specs_json` member for that product, optionally accompanied by aliases and source identities. This
-  preserves the 142-key sparse tail without turning `products.tsv` into mostly-empty columns.
+  `specs_json` member, optionally with aliases and source identities. This preserves the 142-key sparse
+  tail without turning `products.tsv` into mostly-empty columns.
 
-The two alternate slug-keyed views (`by-hardware-slug.tsv`, `by-www-slug.tsv`) should be **dropped**.
-Both `source_hardware_slug` and `source_www_code` are already columns on `products.tsv`, and both are
-near-unique per product, so the alternate files would be the same rows in a different sort order minus
-the products lacking that source. A spreadsheet user sorts a column; they do not need a third file to do
-it. If a genuine need appears later it is a trivial re-emit.
+The earlier page-byte idea is dropped: the catalog stores normalized www facts, not raw `/hardware` or
+www page bodies. The size-like audit signals here are row counts, alias counts, `spec_count`, and
+per-key coverage.
 
-The earlier page-byte idea was mistaken and is dropped. The catalog stores normalized www facts, not
-raw `/hardware` or www page bodies. Useful size-like audit signals here are row counts, alias counts,
-`spec_count`, and per-key coverage across products—not byte counts of `specs_json`.
+## Properties
 
-## Properties and section identity
+`properties.tsv` joins `properties` to `pages` for `slug`/`rosetta_id`, numeric page ID, title, URL, and
+the stored property fields.
 
-This was the briefing's "measure it before declaring a migration" item. It has been measured, and the
-finding is stronger than expected: **`properties.section` storing heading text rather than a section
-identity is actively destroying data in the shipped artifact.**
+Section identity is a schema problem, not an export problem — **#90**. `properties.section` stores
+heading text, which destroys 165 properties on insert and leaves 28% of survivors unresolvable to a
+section. The resolution logic does not belong in `export`; the exporter should emit `section` as stored
+plus a resolved `section_anchor` where the join is unique, leaving it empty where it is not, so the file
+shows the gap rather than papering over it. Once #90 lands, `section_id` makes this direct.
 
-Of 4,575 properties parsed from the current corpus, only **4,410 are stored**. The
-`UNIQUE(page_id, name, section)` constraint combined with `INSERT OR IGNORE` silently discards **165
-rows** — a property whose page has two same-named headings collapses into whichever came first. Real
-examples: `ppp-aaa` loses `comment`, `local-address`, `name`, and `remote-address` because the page has
-several `Properties` headings; `dot1x` loses `interface` under a repeated `Server`. Nothing reports this.
+## Pages, fragments, and tables
 
-Of the 4,410 that survive, joining `properties.section` to `sections.heading` within a page gives:
-
-| Result | Rows | Share |
-|---|---|---|
-| Unique match | 3,191 | 72% |
-| Ambiguous (2–8 candidate sections) | 718 | 16% |
-| No matching section row at all | 501 | 11% |
-
-The two failure modes have distinct, already-understood causes in `extract-docusaurus.ts`:
-
-- **The 501 "no match" are not missing data — they are a level mismatch.** `parseProperties` tracks
-  `currentSection` from `#{1,6}` headings; `parseSections` only mints section rows for `#{1,3}`,
-  deliberately folding deeper headings into the enclosing section's text. So every property under an
-  h4–h6 heading records a `section` string that cannot exist in `sections`. The corpus has 817 h4–h6
-  headings against 4,098 h1–h3, and a sample of "no match" values (`Certificate template properties`,
-  `Advanced Monitor`, `Port Resources/Usage`, …) confirmed all were h4–h6.
-- **The 718 ambiguous are a discarded disambiguation.** `parseSections` already resolves duplicate
-  headings into unique `anchor_id`s (`foo`, `foo-1`, `foo-2`); `properties` stores the raw heading text
-  and throws that away. The corpus has 86 page/heading pairs that repeat, worst offenders being
-  `layer2-misconfiguration` (`Problem`/`Solution`/`Symptoms`, 18× each) and `user-manager`/`ipsec`
-  (`Properties`, 8× each).
-
-This reframes the fix. It is not a speculative schema migration justified by export convenience: both
-parsers already walk the same Markdown, line by line, in the same extraction pass. Correlating a
-property to the section whose line range contains it is local work, and `section_id` then makes the
-`UNIQUE` constraint correct instead of lossy. The export is what made the loss visible; the loss would
-be worth fixing even if the export were abandoned.
-
-The honest interim behavior for `properties.tsv` is to emit `section` as stored plus a resolved
-`section_anchor` where the join is unique and empty where it is not, so the file shows the 28% rather
-than papering over it.
-
-## Pages, fragments, and generic tables
-
-`pages.tsv` can provide two kinds of row in one pivot-like audit view:
+`pages.tsv` provides two kinds of row in one pivot-like audit view:
 
 - a page rollup with `rosetta_id`, `slug`, `title`, `url`, stored `word_count`, derived text/code byte
   counts, section count, and table counts; and
 - one row per `sections` record with `anchor_id`, `heading`, `level`, `sort_order`, `word_count`, byte
   counts, and table/table-row counts for that fragment.
 
-The scalar metrics are straightforward and immediately useful as MCP/TUI evidence. Pages average 13KB of
-text but run to **153KB** (`bridging-and-switching`, 21,626 words, 50 sections); the ten largest pages
-are 17.6% of all page bytes. Sections are far better behaved: p50 730B, p90 3.3KB, p99 10.7KB, max 34KB.
-That ~200× page-level spread against a ~15× section-level spread is a concrete argument that sections,
-not pages, are the sane retrieval unit, and that any page-level `limit` is really a truncation policy.
-The census also found **129 empty sections** (4.4%) — headings with no body — which retrieval currently
-treats as real fragments.
+The **sizing** is the point here, not the content. Pages average 13KB of text but reach **155KB**
+(`bridging-and-switching`); sections are far better behaved at p50 730B, p90 3.3KB, p99 10.7KB, max 34KB.
+That spread is a concrete argument that sections, not pages, are the sane retrieval unit, and that any
+page-level `limit` is really a truncation policy. The 129 empty sections (4.4%) should be *flagged* — the
+existing `word_count = 0` is enough — but they are not an export problem; their cost is a wasted
+`get_page(section=)` call, which is #93.
 
-The generic-table question is now answered, and it is not the hard part the briefing assumed:
+**Tables are the reason this family matters.** The corpus has 852 pipe tables (8,258 data rows) across
+180 pages, of which **595 are property-shaped and already extracted, and 257 are discarded entirely**.
+The uniformity is good news: zero HTML `<table>` elements, no MDX table forms, 79% two-column, and only
+**14 genuinely ragged tables** — a small enough exception set to enumerate and handle deliberately rather
+than guess at.
 
-| Measure | Result |
-|---|---|
-| Pipe tables | 855 across 180/365 pages, 8,278 data rows |
-| HTML `<table>` elements | **0** |
-| Genuinely ragged tables | **14** (1.6%) |
-| Empty-header (layout) tables | 28 |
-| Two-column tables | 672 (79%) |
-| Property-like header (`Property`/`Parameter` …) | **596 (70%)** |
-| Non-property tables | **259** |
-| Fragments containing >1 table | 85 / 704 (12%) |
+The direction (#92) is to invert the current order: parse **all** tables generically in core, then filter
+the property-shaped ones to keep MCP/TUI behaviour unchanged. Exporting only the tables today's schema
+happens to model would pre-filter the corpus by the very assumption the audit exists to test. The 70%
+overlap is evidence that `properties` and the table corpus are the same corpus viewed twice.
 
-Three conclusions follow, two of which cut against the original framing:
+Why all tables, beyond the export: large pages need natural seams to split on, and tables are one of the
+few; `routeros_get_page` could return tables structurally instead of as Markdown the model re-parses; and
+half a dozen "special tables" are already known to be worth promoting (B-0007), with no way to discover
+the rest today.
 
-1. **There is no HTML/MDX table problem.** The worry about distinguishing pipe tables from "raw HTML/MDX
-   forms" was unfounded: the corpus contains zero `<table>` elements. The shape is uniform pipe syntax,
-   overwhelmingly two columns, and 98.4% of tables are internally consistent. A parser is small.
-2. **But 70% of tables are already `properties`.** The generic table corpus is mostly a less-structured
-   copy of a table rosetta already extracts. Only **259 tables carry information not already modeled**.
-   That materially weakens "export every table as a file" and strengthens the narrower question: what is
-   in those 259?
-3. **Naive parsing is a trap, and the fix is not exported.** RouterOS enum values pervade these tables as
-   escaped pipes (`*md5 \| sha1 \| sha256*`), and **1,422 cells contain a literal `|` after unescaping**.
-   A `line.split("|")` implementation reports 374 "ragged" tables — 44% — that are simply wrong; the true
-   figure using escape-aware splitting is 14. `extract-docusaurus.ts` already has correct
-   `splitTableRow`, but it is **module-private and not exported**. Any second implementation will
-   re-introduce this bug, and it is the same reason a downstream `awk -F'|'` consumer would silently
-   corrupt data.
-
-So the useful next probe is not "can we parse tables" but "are the 259 non-property tables worth
-promoting". Emitting per-fragment table files for the 70% that duplicate `properties` would add files
-without adding knowledge.
-
-This still matters beyond the exporter. A generic stored-table representation could retain page/section
-context, headers, rows, ordinals, and perhaps raw source; `routeros_get_page` could then return tables
-structurally. Property extraction might eventually become a classification over that generic corpus
-rather than the only special table parser — the 70% overlap is evidence that this is the *same* corpus
-viewed twice, not two corpora. The device-specific tables in B-0007 may still deserve normalized domain
-schema.
+Per-fragment table files (`pages/<page-slug>/<fragment>[--N].tsv`) are therefore in scope, with 85 of 701
+fragments containing more than one table and needing a deterministic suffix.
 
 ## Callouts
 
-`callouts.tsv` directly supports page, type, order, and text, but `callouts` has no section/fragment FK.
+`callouts.tsv` directly supports page, type, order, and text. `callouts` has no section attribution — the
+same root as #90, and the same conclusion: the extractor already tracks heading context while parsing
+properties and simply does not record it for callouts. That belongs in ETL, not in `export`.
 
-The briefing suggested re-parsing `pages.text` to recover heading context, and worried it would duplicate
-extraction logic. That framing was wrong in a useful way: `parseProperties` **already tracks
-`currentSection`** while walking the same Markdown. `parseCallouts` simply does not — it tracks a fence
-stack and sort order and never looks at headings. So callout section attribution is not a re-parse
-problem or an export problem; it is a field the extractor is positioned to record and does not. That
-belongs with the `section_id` work above, not in the exporter.
-
-`callouts.content` is also the **only** multiline scalar in the export set — see below.
+`callouts.content` is the only multiline scalar in the export set (162 of 943 rows). It is not long
+enough to justify sidecars, which would make it *less* readable; encode it in place — see below.
 
 ## Commands
 
-The original instinct — keep this shallow, just round out the export — does not survive contact with the
-data. `commands-by-version.tsv` as specified would be actively misleading.
+Keep commands shallow, but narrow rather than loose. `commands.type` gives `dir`/`cmd`/`arg` counts
+directly (572 / 5,296 / 36,099 of 41,967), so those need a definition, not new logic.
 
-The direct part is fine: `commands.type` gives `dir`/`cmd`/`arg` counts straight (550 / 5,097 / 34,948 of
-40,595), so those columns need only a definition, not new logic.
+Per-version path counts must wait on **#91**: `command_versions` has no `arch` column while 18 versions
+exist for both x86 and arm64, and extraction is delete-then-reinsert, so those path sets are
+last-writer-wins. A version→count column would present one architecture's number as a fact about the
+version. Either omit it or carry an explicit `arch_unknown` marker until #91 lands.
 
-The version dimension is the problem. `command_versions` has PK `(command_path, ros_version)` — **no
-architecture column** — while `ros_versions` has PK `(version, arch)` and holds both `x86` and `arm64`
-rows for **17 versions** (7.20.8 through 7.24rc1). `extract-commands.ts` runs
-`DELETE FROM command_versions WHERE ros_version = ?` and then re-inserts. That is **last-writer-wins**,
-not a merge: for those 17 versions the stored path set reflects whichever architecture was extracted
-last, and which one that was is not recorded anywhere. A version→path-count column would present that as
-a fact. This is worse than the briefing's "not durably representable today" — the data is not merely
-un-exportable per-arch, it is silently one arch wearing the label of the version.
+Versions must use the existing numeric/beta/RC comparator, never SQL lexical order — `7.9.2` sorts above
+`7.24rc1` as a string, which is exactly how this pass briefly reached a wrong conclusion about arch
+coverage.
 
-Two further traps sit next to it:
+`schema_nodes`/`schema_node_presence` are populated (41,967 nodes, pruned to a single active head) and
+working as designed per `command-versions-vs-presence.instructions.md`. Per-architecture command work
+stays with #25/#33.
 
-- `schema_nodes` and `schema_node_presence` are **empty** (0 rows) in the current local DB.
-  `release.yml` only runs `extract-all-versions.ts` when the `full_versions` input is set, otherwise it
-  runs `extract-commands.ts`. So whether these tables ship populated is a per-release property. An export
-  that reads them will produce an empty file for some releases and data for others, with no explanation.
-  The manifest should record which path built the DB. (Whether published release assets actually ship
-  them populated is unverified here and should be checked against a real release asset, not inferred
-  from this local file.)
-- The version comparator warning is real and easy to underestimate. Preparing this pass, a
-  `MIN/MAX(version)` query reported x86 as spanning only 7.1.1–**7.9.2**, which is lexical nonsense —
-  `7.9.2` sorts above `7.24rc1` — and led to a wrong conclusion about arch coverage until it was caught.
-  Any exporter touching versions must use the existing comparator, and the census scripts should too.
+# Schema/ETL findings, now tracked
 
-The right move is to keep commands shallow by **narrowing** rather than by summarizing loosely: emit the
-`dir`/`cmd`/`arg` totals and the version list, and either omit per-version path counts or carry them only
-with an explicit `arch_unknown` marker until `command_versions` can distinguish. Per-architecture command
-work stays with the existing command/CLI Reference issues; this briefing should hand them a measured bug
-rather than pull their scope forward.
+The audit's findings are GitHub issues under umbrella **#95** (label `export-audit`), not prose here:
 
-# Schema/ETL findings this audit produced
+| Issue | Finding |
+|---|---|
+| [#90](https://github.com/tikoci/rosetta/issues/90) | 165 properties destroyed on insert; `properties.section` is heading text (28% unresolvable); `callouts` has no section attribution |
+| [#91](https://github.com/tikoci/rosetta/issues/91) | `command_versions` arch-blind; 18 dual-arch versions are last-writer-wins |
+| [#92](https://github.com/tikoci/rosetta/issues/92) | 257 non-property tables discarded; `splitTableRow` module-private; parse all tables, filter property-shaped |
+| [#93](https://github.com/tikoci/rosetta/issues/93) | 129 empty sections waste a `get_page(section=)` call |
+| [#94](https://github.com/tikoci/rosetta/issues/94) | No check that the resolved DB matches the codebase |
 
-The directional questions have largely resolved into findings. Ordered by confidence and materiality:
+None of them block `export`, and `export` does not block any of them. The intended order is to fix the
+important ones first, then build the first `export` against a corrected schema.
 
-1. **Confirmed data loss — properties.** 165 of 4,575 parsed properties are silently dropped by
-   `UNIQUE(page_id, name, section)` + `INSERT OR IGNORE`, because `section` is heading text. Fixing
-   section identity fixes the loss. This deserves an issue on its own merits, independent of `export`.
-2. **Confirmed integrity bug — command_versions.** Arch-blind PK plus delete-then-reinsert makes 17
-   versions' path sets last-writer-wins between x86 and arm64. Deserves an issue; likely belongs to the
-   existing command/CLI Reference thread rather than a new one.
-3. **Confirmed design gap — section identity.** 28% of properties cannot be uniquely resolved to a
-   section (11% because sections stop at h3 while properties track to h6; 16% because `anchor_id`
-   disambiguation exists but is discarded). Callouts have no section attribution at all despite the
-   extractor already tracking it for properties. One `section_id` change addresses all three.
-4. **Resolved — generic tables are easy to parse but mostly redundant.** 855 tables, 0 HTML, 1.6%
-   ragged, but 70% already modeled as `properties`. The open question shrinks to the 259 non-property
-   tables. `splitTableRow` needs exporting before anything else parses a table.
-5. **Resolved — product spec head.** 142 keys, coverage cliff at ~74%, and `specs_json` mixes
-   underscore-prefixed provenance with real specs. Alternate slug-keyed views are redundant.
-6. **Resolved — TSV is safe.** See below.
-7. **Open — release-conditional tables.** `schema_nodes`/`schema_node_presence` populated only on
-   `full_versions` releases; the manifest should say which.
-
-Transcript provenance is a real gap already scoped in [#21](https://github.com/tikoci/rosetta/issues/21).
+Also open and out of scope here: #21 (transcript provenance), #25/#33 (arch + CLI Reference), B-0007
+(device-capability tables).
 
 # Strawman local directory
-
-The structure below reflects the census: the two slug-keyed product views are gone, and per-fragment
-table files are held back pending the 259-table question.
 
 ```text
 rosetta-datasets/
@@ -358,103 +292,105 @@ rosetta-datasets/
 ├── pages.tsv
 ├── commands.tsv
 ├── callouts.tsv
-└── products/
-    ├── products.tsv
-    ├── matrix.tsv
-    └── <rosetta-device-id>/
-        └── specs.tsv
+├── products/
+│   ├── products.tsv
+│   ├── matrix.tsv
+│   └── <rosetta-device-id>/
+│       └── specs.tsv
+└── pages/
+    └── <page-slug>/
+        ├── <fragment>.tsv
+        └── <fragment>--2.tsv
 ```
 
-`manifest.toml` can carry richer structure than a TSV: database/package/schema/release provenance from
-`db_meta`, generated file names and row counts, coverage summaries, and known omitted/unavailable
-fields. It is the natural home for the census results that do not fit one flat row shape, and for the
-honest disclosures this pass has identified — the properties that lost their section, whether the DB was
-built with `full_versions`, and which architecture claim cannot be made. JSON remains a possible future
-bulk dataset format, not a requirement of this local pass.
+The two alternate slug-keyed product views are not included: `source_hardware_slug` and `source_www_code`
+are already columns on `products.tsv`, so a spreadsheet user sorts a column instead of opening a third
+near-identical file.
 
-Subdirectories are not restricted to TSV forever. For example, a later video detail export could use
-`transcript.txt` plus `metadata.toml`.
+`manifest.toml` carries what a TSV cannot: `db_meta` provenance (release tag, schema version, source
+commit, build time), generated file names and row counts, coverage summaries, and honest disclosures —
+which fields are unavailable and why, and which claims the data cannot support (per-version architecture,
+until #91).
+
+Subdirectories are not restricted to TSV forever; a video detail export could pair `transcript.txt` with
+`metadata.toml`.
 
 # TSV as the working tabular format
 
-TSV is a reasonable default, and the consumer-mismatch worry is now mostly retired by measurement rather
-than by testing a matrix.
+TSV is the working default. GitHub and editors render it, spreadsheets import it, it resembles direct SQL
+output, and it is lighter than CSV for data whose values routinely contain commas.
 
-**The corpus contains no tabs.** Zero across `properties.description`, `properties.name`,
-`changelogs.description`, `callouts.content`, `pages.title`, `video_segments.transcript`, and all 8,278
-Markdown table cells. The hope that ETL avoids tabs is not a hope; it is a measured property. So plain
-tab-delimited output with no quoting is lossless for every scalar in the export set, and stays parseable
-by `awk -F '\t'` and RouterOS `:deserialize`.
+The corpus supports it. **No scalar column an export would emit contains a tab** — verified across
+`properties.description`, `properties.name`, `changelogs.description`, `callouts.content`,
+`video_segments.transcript`, and all 8,258 Markdown table cells. Tabs exist only inside fenced code blocks
+in `pages.text` (13 pages), which never become a TSV cell. So plain tab-delimited output with no quoting
+is lossless and stays parseable by `awk -F '\t'` and RouterOS `:deserialize`.
 
-**One exception:** `callouts.content` contains newlines in **163 of 945 rows** (17%). That is the whole
-of the multiline problem, and it is confined to one column of one file. Rather than adopting quote-aware
-TSV corpus-wide — which would cost every simple consumer the one-line-equals-one-record property to
-serve 163 rows — the proportionate options are a documented reversible escape for that column, or moving
-callout bodies to sidecars while `callouts.tsv` keeps type/order/page and a reference. The earlier
-three-way consumer matrix does not need running; it only needs deciding for this one column.
+The one exception is newlines in `callouts.content` (162 rows). Adopting quote-aware TSV corpus-wide would
+cost every simple consumer the one-line-equals-one-record property to serve those rows, and sidecars would
+hurt readability for content this short. Encode in place instead: a documented, reversible escape, or a
+Unicode replacement/visible-marker convention.
 
-The serializer still needs defined behavior if a tab ever appears, since "measured absent today" is not
-"impossible tomorrow" — but that is a guard, not a design constraint.
+More generally, **`export` should guard rather than assume**. "No tabs today" is a measured property, not
+an invariant, so the serializer needs defined behavior — a reversible re-encoding backstop against any
+value that would produce invalid TSV, applied as a general rule and not only to callouts. A companion
+ETL-hygiene test asserting the absence of tabs outside code blocks is probably worth having on its own
+merits (#92 is the natural home, since it also needs an escaped-pipe test).
 
-Whatever shape wins should be UTF-8 with LF endings, a header row, stable row/column ordering, explicit
-SQL `NULL` handling, and a single shared word-count rule. Raw slugs and fragments stay in columns even
-when filesystem-safe names must be sanitized.
+Output is UTF-8 with LF endings, a header row, stable row/column ordering, explicit SQL `NULL` handling,
+and a single shared word-count rule. **Raw slugs and fragments stay in columns** even where filesystem-safe
+names must be sanitized — and where a row corresponds to a generated file or directory, the encoded name
+should be its own column so the match is definitive rather than reconstructed.
 
-Note the corpus does contain 1,422 table cells with literal `|`. That does not affect TSV output, but it
-is why any consumer or second implementation that splits Markdown tables on `|` is wrong.
+`export` must not invent its own Markdown parser. The shared `splitTableRow` (#92) is the single
+implementation; sharpen it where needed and handle shape differences after parsing. Note 1,420 table cells
+contain a literal `|` after unescaping — which is why a naive `split("|")` reports 374 ragged tables
+against a true 14, and why a downstream `awk -F'|'` consumer would silently corrupt data.
 
 # Working direction
 
-Proceed by using the export idea to **measure and expose** the current artifact, not by designing every
-future schema now. The census has done much of that already and shifted the weight: the interesting
-output of this briefing is turning out to be the schema findings, with the files as the instrument that
-produced them.
-
-Two course corrections against the earlier draft:
-
-- **Products got simpler** (three near-identical views collapse to one catalog plus per-product specs).
-- **Commands got harder** (the "KISS summary" would have shipped an arch-mixed number as a fact).
+Use the export to **measure and expose** the current artifact rather than to design every future schema.
+Products resolve to one catalog plus per-product specs. Pages/tables are the highest-value and least
+settled area, and the decision there is to take all tables rather than only the ones today's schema
+models. Commands stay narrow, and honest about what #91 prevents them from claiming.
 
 The first useful output should favor honest omissions and coverage summaries over cache fallbacks or
-complex re-parsing hidden inside `export`. Schema improvement should not block getting files — but the
-properties data loss is now confirmed rather than suspected, and it should not wait on `export` either.
+re-parsing hidden inside `export`. Schema fixes and the export are independent tracks, sequenced only
+because building the export against a corrected schema is less wasted work.
 
 # Next steps
 
-Session-scoped items, each independently useful. None require adding `export` to core code.
+Session-scoped, in the intended order. The first three are #95 work, not export work.
 
-1. **File the properties data-loss issue.** The 165-row loss, the 72/16/11 split, and the h3-vs-h6 and
-   `anchor_id`-discard causes are all measured with examples. Scope: carry `section_id` on `properties`
-   and `callouts` by correlating line ranges in the existing single parse pass; make `UNIQUE` use
-   `section_id`. Cite this briefing. Do this first — it is a shipped-data bug, not export scope.
-2. **File the `command_versions` arch issue** against the existing command/CLI Reference thread, with
-   the 17 dual-arch versions and the delete-then-reinsert mechanism. Decide there whether the PK gains
-   `arch` or extraction refuses to overwrite across arches.
-3. **Export `splitTableRow`** from `extract-docusaurus.ts` (plus a test asserting escaped-pipe handling).
-   One-line change that prevents the 44%-wrong second implementation this pass already stumbled into, and a
-   prerequisite for any table census script living in the repo.
-4. **Census the 259 non-property tables** — the one table question still open. Group them by header
-   shape and page, and decide whether they are (a) device/capability tables belonging to B-0007, (b)
-   worth a generic stored-table representation, or (c) noise. This is the input to the biggest schema
-   decision in the briefing and is a scripting task, not a code change.
-5. **Prototype two files throwaway** — `products.tsv` and `pages.tsv` — against a scratch Docusaurus DB,
-   and open them in Numbers and GitHub. These are the two with real shape questions (spec head selection;
-   page-vs-section rows in one file). Keep it out of `src/`; the point is to answer the layout question
-   before any `export` command exists.
+1. **#90 — properties data loss + section identity.** Highest value: real loss in the shipped artifact,
+   self-contained (both parsers already walk the same Markdown in one pass), and a prerequisite #92 and
+   #93 both want. The one open decision is whether h4–h6 headings mint section rows or resolve to their
+   nearest h1–h3 ancestor; the latter preserves the retrieval unit and is the likely answer.
+2. **#92 step 1 — export `splitTableRow` with an escaped-pipe test.** One-line change that prevents the
+   44%-wrong second implementation, and unblocks any table work.
+3. **#92 steps 2–3 — generic table representation, properties derived as a filter.** The largest schema
+   change in the briefing; wants #90's section identity first.
+4. **Census the 257 non-property tables** before or during step 3 — group by header shape and page to
+   inform the generic schema and to tell B-0007's device tables apart from the rest. Cheap, and it is the
+   input to the biggest design decision here.
+5. **First `export`, later session.** Reuse normal DB resolution/readiness, `exportDevicesCsv()`, and the
+   shared table parser; share deterministic TSV/TOML/path helpers. Overwriting previous output is the
+   working assumption; safe replacement needs definition before implementation.
 
-Deferred deliberately: publication/Pages layout, retention, compression, JSON, and overwrite/replacement
-semantics. None of them can be decided well before the file set stabilizes.
+# Deferred deliberately
 
-# Questions for the next pass
+Publication and Pages layout, release/version URL scheme, retention, compression, caching, and large-scale
+JSON. All depend on the local output proving useful.
 
-- **Is `products.tsv` keyed correctly?** It assumes `hardware_catalog.rosetta_device_id` is the product
-  identity, which makes 99 matrix-less products first-class rows. If the intended audience thinks in
-  matrix terms, that is 39% surprising rows; if they think in catalog terms, `devices` is the surprising
-  view. This drives the whole family's shape.
-- **Do the 129 empty sections and the 153KB page belong in `pages.tsv` as-is,** or is the census
-  actually pointing at a retrieval-unit issue worth its own briefing? The size data seems more valuable
-  to MCP/TUI work than to the export, and may be escaping this briefing's scope.
-- **Is `export` still the right vehicle** if the schema findings are the main product? An honest reading
-  of this pass is that a `scripts/census.ts` would have produced findings 1–5 without shipping a user
-  surface. `export` is still worth building for the spreadsheet audience — but that is a product
-  argument, not the audit argument, and the briefing should probably say which one is load-bearing.
+Also deferred: **alternative directory groupings** — spinning `pages/` on Docusaurus TOC parents, or
+`products/` on device categories, rather than a flat slug/id layout. Grouping is a real readability
+question for a human browsing the output, but it should follow a stable file set rather than shape it.
+
+# Open questions
+
+- Does `pages.tsv` mixing page-rollup and section rows in one file actually read well in a spreadsheet,
+  or does the pivot-like shape want splitting once real data is in front of us? This is a "look at it in
+  Numbers" question, not an argue-about-it question.
+- Is the page/section sizing data escaping this briefing's scope? It is arguably more valuable to the
+  MCP/TUI retrieval-unit work (#27) than to the export, and may deserve its own briefing rather than
+  living here as a byproduct.

--- a/briefings/B-0022-runtime-sqlite-dataset-exports.md
+++ b/briefings/B-0022-runtime-sqlite-dataset-exports.md
@@ -18,9 +18,13 @@ The proposed first surface is deliberately small:
 bunx @tikoci/rosetta export /tmp/rosetta-datasets
 ```
 
-It creates one directory containing a deterministic set of TSV files. There are no CI or GitHub Pages
-changes in this pass, and no flags for partial exports, formats, or other options. (`@tikoci/rosetta`,
-with a slash, is the canonical package name.)
+It creates a directory containing a predictable set of top-level summary files plus subdirectories
+where a subject naturally has per-item detail (for example, product specs or page tables). A future
+subdirectory might carry non-tabular details such as transcript text and metadata, but the initial pass
+does not need to export every DB value in every possible representation.
+
+There are no CI or GitHub Pages changes in this pass, and no flags for partial exports, formats, or
+other options. (`@tikoci/rosetta`, with a slash, is the canonical package name.)
 
 # Why this is worth doing
 
@@ -35,6 +39,11 @@ rosetta actually ships:
 - Page, section, table, word, row, and byte distributions can expose unbalanced retrieval units and
   inform later MCP/TUI work such as `limit` behavior or first-class handling for unusually large or
   structured pages.
+- MikroTik itself is a plausible audit audience while the Docusaurus manual is still new. A TSV that
+  makes missing values in a column visible is easier to discuss than a SQL recipe or agent-generated
+  prose summarizing internal queries, and it can point directly at source-documentation gaps.
+- Many MikroTik users, administrators, and partners already work in spreadsheets and do not use AI
+  agents. Rosetta's ETL can still provide useful standalone data to them through familiar tools.
 - A deterministic directory is a natural precursor to publishing release-scoped static datasets on
   GitHub Pages, where `curl`, `fetch()`, `requests`, and `awk` can consume ETL results without speaking
   SQLite, MCP, or the TUI.
@@ -60,122 +69,262 @@ In particular, the first pass must not fall back to:
 An unavailable column should be omitted or explicitly documented as unavailable. Recovering it from a
 cache would defeat the audit.
 
-# What the current SQLite shape can support
+The target is the current Docusaurus-built runtime artifact. The exporter does not need a reduced
+compatibility mode for historical Confluence release databases. If current extraction leaves
+Confluence-sourced page rows in the release DB, that is a data-integrity finding to surface rather than
+an alternate export contract to design around.
 
-This is a feasibility inventory, not a final column contract. Names below are descriptive rather than
-normative, and `#`-style count ideas are written as machine-friendly `*_count` columns.
+# Working export families and current feasibility
 
-| Candidate export | DB-only feasibility today | Current grounding and gaps |
-|---|---|---|
-| `changelog.tsv` | Ready | `changelogs` directly stores `version`, `is_breaking`, `category`, and `description` (plus `released` and source order). The requested `version`, `breaking`, `category`, `text` view is a direct query. |
-| `videos.tsv` | Mostly ready | `videos` stores title, upload date, YouTube ID/URL, and whether chapters exist. Joining `video_segments` provides segment/chapter counts plus transcript word and UTF-8 byte counts. The DB does **not** retain transcript provenance/type such as auto-generated vs. manual or language/track; `has_chapters` can only support a derived layout label such as `chaptered` vs. `full-video`. Full transcript text is already stored, so future per-video text/metadata directories remain DB-only feasible. |
-| `properties.tsv` | Mostly ready | `properties` joins to `pages` for page slug/`rosetta_id`, numeric page ID, title, and URL; `properties.section` records the nearest heading text. It does not FK directly to `sections.id` or store the exact `anchor_id`, so a guaranteed fragment URL requires a schema improvement (or a potentially ambiguous heading-text join when headings repeat). |
-| `devices-matrix.tsv` | Ready | `devices` contains the normalized product-matrix fields. The existing `rosetta://datasets/devices.csv` query is the obvious query/column source to reuse, changing only the serialization to TSV rather than rebuilding the view from matrix files. |
-| `devices-by-hardware-slug.tsv` | Mostly ready | `hardware_catalog.source_hardware_slug` can be the row key; `device_id IS NOT NULL` answers `has_matrix`; `devices` provides CPU/RAM fields; `specs_json` carries broad www specs including `Switch chip model` when present. A `/hardware` page's raw body and byte size are **not** stored in this catalog, so only stored-spec JSON bytes can be reported, not hardware-page bytes. |
-| `devices-by-www-slug.tsv` | Mostly ready | `hardware_catalog.source_www_code` supplies the www path token, with the same matrix/spec joins and an optional `/hardware` URL derived from `source_hardware_slug`. The DB retains normalized www specs, not the raw www page body, so raw page byte counts are unavailable. Rows without a www source naturally do not appear in this keyed view. |
-| `pages/<page-slug>/<fragment>.tsv` | Conditionally feasible | Current Docusaurus rows retain raw Markdown in `pages.text` and section Markdown in `sections.text`, so a small runtime parser can extract generic Markdown tables without touching a cache. Tables are not normalized in SQLite, however, and legacy Confluence rows do not have the same Markdown contract. Duplicate fragments/multiple tables under one heading need deterministic suffixes such as `--2`; unsupported MDX/HTML tables must be reported rather than guessed. |
-| `pages.tsv` | Mostly ready | Page and fragment rows can carry slug/`rosetta_id`, title, URL, stored word counts, and UTF-8 byte counts derived from `pages.text` / `sections.text`; page rows provide the rollup. Table counts and table-row counts depend on the same DB-resident Markdown parser above because the schema does not store generic tables. |
-| `commands-by-version.tsv` | Mostly ready | `command_versions`, `commands`, `schema_nodes`, `schema_node_presence`, and `ros_versions` support per-version path/type counts and provenance. RouterOS versions must use the existing numeric/beta/RC comparator, not SQL lexical order. `ros_versions` can indicate which x86/arm64 deep-inspect inputs existed, but `schema_node_presence` lacks an architecture column, so exact per-version, per-architecture node counts are not durably representable today. The meanings of `cmd_count`, `dir_count`, `path_count`, and `arg_count` also need one explicit definition each before becoming a contract. |
-| `callouts.tsv` | Conditionally feasible | `callouts` directly provides page, type, order, and text. It has no section/fragment FK. Current Docusaurus Markdown can be re-parsed from `pages.text` to recover heading context, but that duplicates extraction logic and does not give legacy rows the same guarantee. Persisting `section_id` or `anchor_id` during ETL would make page+fragment a direct, auditable export. |
+This is a feasibility inventory, not a final filename or column contract. Direct columns should
+generally retain their SQLite names: the correspondence makes each export easier to trace and acts as a
+loose column-name audit. Derived or joined values still need names chosen for clarity in the file where
+they appear; matching SQL mechanically is less important than accurately describing the value.
 
-## Immediate schema/ETL audit findings
+## Changelog
 
-The exercise already exposes four concrete storage questions worth keeping visible even if the initial
-export simply documents the gaps:
+`changelog.tsv` is directly feasible. `changelogs` stores `version`, `is_breaking`, `category`,
+`description`, `released`, and source order. The original `version`, `breaking`, `category`, `text`
+sketch should therefore lean toward the existing names (`is_breaking`, `description`) unless the wider
+export context shows a good reason to rename them.
 
-1. Should transcript source metadata (track language and auto/manual provenance) be retained alongside
-   `videos` or `video_segments`?
-2. Should `properties` and `callouts` carry a direct `section_id`/fragment identity rather than only
-   heading text (properties) or no fragment context (callouts)?
-3. Should generic Markdown tables become normalized ETL data, or is re-parsing DB-resident Markdown at
-   export time intentionally sufficient? B-0007 independently identified the same generic-table
-   question for device-capability pages.
-4. Does command presence eventually need `(node, version, arch)` rather than `(node, version)` if
-   architecture-specific audit exports are a desired contract?
+## Videos
 
-Raw `/hardware` and www document byte counts are a different boundary: rosetta currently stores their
-catalog identity and normalized facts, not those source documents as page corpora. Adding byte counts
-would require deliberately retaining a body or source-size fact during ETL; an exporter cannot recreate
-them honestly from `specs_json`.
+`videos.tsv` is mostly direct. `videos` stores title, upload date, YouTube ID/URL, duration, view/like
+counts, and whether chapters exist. Joining `video_segments` provides segment/chapter counts plus
+transcript word and UTF-8 byte counts. Full transcript text is also in the DB, so a later
+`videos/<video_id>/` detail directory could remain within the DB-only constraint.
+
+The schema does not yet retain transcript provenance such as automatic vs. author-provided. That is
+already tracked by [#21](https://github.com/tikoci/rosetta/issues/21), including the proposed
+`transcript_source` field and the harder question of how reliably it can be detected. It should not
+block this export: omit the field now, make the gap visible in the manifest, and add it when the DB can
+provide it.
+
+## Products
+
+The product data is better considered one family than a collection of unrelated `devices-*` files.
+`devices`, `hardware_catalog`, `device_aliases`, and `hardware_catalog.specs_json` collectively represent
+rosetta's product knowledge across the matrix, `/hardware`, and www product sources.
+
+Likely useful views to probe are:
+
+- **`products/products.tsv`** — one row per `hardware_catalog.rosetta_device_id`, including source
+  identities/slugs, display name/category/lifecycle, matrix presence and common matrix fields, alias
+  count, spec count, and a deliberately small set of high-coverage/useful www specs such as CPU,
+  architecture, RAM, storage, switch chip, power, and port counts. This is the closest DB-only successor
+  to the manually produced `hardware-www-matrix.csv`, but should be a richer combined catalog rather
+  than merely re-exporting `devices`.
+- **`products/matrix.tsv`** — the normalized matrix-backed fields currently exposed as
+  `rosetta://datasets/devices.csv`, if retaining the narrower source-shaped view proves useful beside
+  the combined catalog.
+- **`products/by-hardware-slug.tsv` and `products/by-www-slug.tsv`** — alternate flat views keyed by
+  `source_hardware_slug` or `source_www_code`, with cross-links and the same useful/common columns.
+  These may overlap enough with `products.tsv` that the feasibility pass can simplify them rather than
+  committing to three nearly identical tables.
+- **`products/<rosetta_device_id>/specs.tsv`** — a vertical `name`/`value` expansion of every stored
+  `specs_json` member for that product, optionally accompanied by aliases and source identities. This
+  preserves the sparse long tail without turning `products.tsv` into hundreds of mostly empty columns.
+
+The earlier page-byte idea was mistaken and is dropped. The catalog stores normalized www facts, not
+raw `/hardware` or www page bodies. Useful size-like audit signals here are row counts, alias counts,
+`spec_count`, and per-key coverage across products—not byte counts of `specs_json`.
+
+## Properties and section identity
+
+`properties.tsv` can join `properties` to `pages` for `slug`/`rosetta_id`, numeric page ID, title, URL,
+and the stored property fields. `properties.section` records the nearest heading text, but it does not
+FK directly to `sections.id` or store the exact `anchor_id`. A heading-text join may be ambiguous when a
+page repeats a heading.
+
+That looks like a real schema weakness, but the useful next step here is to measure it rather than
+declare a migration from the briefing: count properties with no section, repeated headings within a
+page, and rows that cannot map uniquely to a stored section. If the materiality is confirmed, a focused
+schema issue can use those results and examples to scope a `section_id`/fragment relationship.
+
+## Pages, fragments, and generic tables
+
+`pages.tsv` can provide two kinds of row in one pivot-like audit view:
+
+- a page rollup with `rosetta_id`, `slug`, `title`, `url`, stored `word_count`, derived text/code byte
+  counts, section count, and any table counts the probe can establish; and
+- one row per `sections` record with `anchor_id`, `heading`, `level`, `sort_order`, `word_count`, byte
+  counts, and table/table-row counts for that fragment.
+
+The scalar page/section metrics are straightforward. Generic table metrics are the uncertain part:
+the current Docusaurus extractor stores raw Markdown in `pages.text` and section Markdown in
+`sections.text`, but does not store generic tables as structured rows. An export-time parser would need
+to scan the DB-resident Markdown, distinguish pipe tables from raw HTML/MDX forms, associate each table
+with a page and nearest fragment, handle multiple tables under one fragment, and identify malformed or
+unsupported shapes without guessing.
+
+Before making that parser a permanent part of `export`, a focused DB-only census should answer:
+
+- how many pages/fragments contain pipe-style, HTML, or MDX-like table shapes;
+- how many tables parse with a simple shared rule and how many are exceptional;
+- how often a fragment contains multiple tables or filename collisions;
+- which headers/shapes recur, especially property-like and device-keyed tables; and
+- how much parsing logic would duplicate or diverge from `extract-docusaurus.ts`.
+
+If the common case stays small and deterministic, emit each table as
+`pages/<page-slug>/<fragment>[--N].tsv` and feed the same parse result into `pages.tsv` counts. If doing
+that honestly requires complex source-specific logic, stopping at the census is itself a useful result:
+it suggests generic tables or a parsed-table JSON representation may belong in ETL/core data rather
+than inside the exporter.
+
+This is more than an export implementation detail. A generic stored-table representation could retain
+page/section context, headers, rows, ordinals, and perhaps raw source; `routeros_get_page` could then
+reconstruct or return tables structurally. Property extraction might eventually become a classification
+or query over that generic table corpus instead of the only special table parser. The device-specific
+tables in B-0007 may still deserve normalized domain schema, but seeing the complete table inventory as
+files is a practical precursor to deciding which tables warrant that promotion.
+
+## Callouts
+
+`callouts.tsv` directly supports page, type, order, and text, but `callouts` has no section/fragment FK.
+Re-parsing `pages.text` could recover heading context for current Docusaurus Markdown, but that would
+duplicate extraction logic just as generic table parsing would. The feasibility probe should measure
+how reliably stored callout content maps to a unique `sections` row. Together with the properties probe,
+this gives concrete scope to the broader finding that page subsections are not consistently represented
+as relationships in the schema.
+
+## Commands
+
+Keep this deliberately shallow. `commands-by-version.tsv` only needs to round out the export with a
+summary of data already present: RouterOS version, total distinct path count, and simple `dir`/`cmd`/`arg`
+counts where the existing tables support them reliably. Versions must use the existing numeric/beta/RC
+comparator rather than SQL lexical order.
+
+Per-architecture counts and a redesign of `schema_node_presence` are not goals here. CLI Reference,
+multi-architecture deep-inspect, and command-schema work already have their own active research/issues;
+this briefing does not need to pull them forward merely to make the export more symmetrical.
+
+# Schema/ETL questions this audit is surfacing
+
+The valuable questions are still directional and evidence-seeking:
+
+1. **Section identity:** how material are the missing/ambiguous property and callout relationships to
+   `sections`, and would a direct `section_id` or stable fragment identity solve both cleanly?
+2. **Generic table storage:** are DB-resident Markdown tables simple enough to parse only for export, or
+   would storing a generic structured representation in ETL unlock better auditing plus MCP/TUI
+   behavior? How would that generic layer coexist with domain-specific promotion for properties and
+   device-capability tables?
+3. **Product catalog shape:** which `specs_json` keys are common/useful enough for the combined summary,
+   and which belong only in per-product key/value files? Do alternate hardware/www keyed views add real
+   audit value beyond identifiers already present in `products.tsv`?
+4. **Artifact readability:** which combination of summary TSVs, per-item TSVs, and non-tabular sidecars
+   makes the DB easiest to inspect without hiding sparse or multiline content?
+
+Transcript provenance is also a real schema gap, but it is already scoped in #21 and is not a question
+this briefing needs to answer. Command architecture is intentionally left to the existing command/CLI
+Reference work.
 
 # Strawman local directory
 
-The first implementation can keep a stable, unsurprising layout while the exact columns remain subject
-to a follow-up issue:
+The structure below is a working aid for the feasibility pass, not a promise that every alternate view
+survives unchanged:
 
 ```text
 rosetta-datasets/
-├── manifest.tsv
+├── manifest.toml
 ├── changelog.tsv
 ├── videos.tsv
 ├── properties.tsv
-├── devices-matrix.tsv
-├── devices-by-hardware-slug.tsv
-├── devices-by-www-slug.tsv
 ├── pages.tsv
 ├── commands-by-version.tsv
 ├── callouts.tsv
+├── products/
+│   ├── products.tsv
+│   ├── matrix.tsv
+│   ├── by-hardware-slug.tsv
+│   ├── by-www-slug.tsv
+│   └── <rosetta-device-id>/
+│       └── specs.tsv
 └── pages/
     └── <page-slug>/
         ├── <fragment>.tsv
         └── <fragment>--2.tsv
 ```
 
-`manifest.tsv` should identify the rosetta/schema/release provenance available in `db_meta`, list each
-generated file and row count, and record intentionally unavailable datasets/fields. That makes a local
-directory self-describing and later gives a static release URL a lightweight inventory without making
-JSON a supported dataset format yet.
+`manifest.toml` can carry richer structure than a TSV: database/package/schema/release provenance from
+`db_meta`, generated file names and row counts, coverage summaries, and known omitted/unavailable
+fields. It is also a natural place for the table/section/product census results that do not fit one flat
+row shape. JSON remains a possible future bulk dataset format, not a requirement of this local pass.
 
-For spreadsheet safety and reproducibility, the likely serialization contract is UTF-8, LF endings, a
-header row, stable row/column ordering, empty fields for SQL `NULL`, and CSV-style double-quote escaping
-using a tab delimiter. Counts should define their unit: UTF-8 bytes via `length(CAST(value AS BLOB))`,
-and a single shared word-count rule rather than subtly different SQL and TypeScript approximations.
-Raw slugs and fragments stay in columns even when filesystem-safe names must be sanitized.
+Subdirectories are not restricted to TSV forever. For example, a later video detail export could use
+`transcript.txt` plus `metadata.toml`; keeping multiline prose out of a summary table may make both the
+table and the detail easier to consume.
+
+# TSV as the working tabular format
+
+TSV is a reasonable default to test. GitHub and editor plugins render it well, spreadsheets commonly
+import it, and it is visually/physically lighter than comma-separated output for data whose ordinary
+values contain commas. It also resembles direct SQL query output and is friendlier to token-based text
+inspection when cells remain simple.
+
+There is one important consumer mismatch to investigate rather than hand-wave: spreadsheet-compatible
+CSV-style quoting with a tab delimiter can preserve literal tabs/newlines, but plain `awk -F '\t'` and
+RouterOS `:deserialize` do not provide the same quote-aware record parsing. Quoted multiline cells also
+break the useful property that one physical line equals one record.
+
+The feasibility pass should therefore test a small consumer matrix and choose intentionally among:
+
+- keeping summary TSV cells single-line and free of literal tabs, with a documented reversible escape
+  for exceptional characters;
+- using quote-aware TSV for exact multiline values and accepting that simple `awk`/RouterOS consumers
+  need a stronger parser; or
+- moving multiline/raw content into per-item `.txt`/`.md` sidecars while TSVs retain summaries and
+  references.
+
+Whatever shape wins should be UTF-8 with LF endings, a header row, stable row/column ordering, explicit
+SQL `NULL` handling, and a single shared word-count rule. Raw slugs and fragments stay in columns even
+when filesystem-safe names must be sanitized. The hope that ETL normally avoids tabs is useful, but the
+serializer still needs defined behavior when a source does contain one.
 
 # High-level plan of attack
 
-1. **Turn this inventory into executable probes.** For every proposed column, write the SQL or small
-   derivation against a runtime DB and mark unavailable fields explicitly. Check both a current release
-   database and focused fixture DBs; do not use source artifacts to make a probe pass.
-2. **Settle the initial column glossary and filenames.** Define count semantics, video transcript-type
-   handling, command count categories, TSV escaping, path sanitization/collisions, and behavior when the
-   destination already exists. Keep this small enough for one no-flags command.
-3. **Build one reusable export core.** Add an `export <directory>` CLI dispatch before MCP startup,
-   reuse existing DB resolution/readiness and device CSV query logic, and share deterministic TSV/path
-   helpers across datasets.
-4. **Land normalized exports first.** Changelog, videos, properties, matrix devices, hardware/www
-   device pivots, page/section scalar metrics, command-version aggregates, and page-level callouts are
-   mostly SQL plus formatting and provide the quickest local audit value.
-5. **Add the DB-resident Markdown pass deliberately.** Reuse/generalize the existing table-row parser
-   patterns, test multiple tables under one fragment and malformed/unsupported tables, then use the same
-   parse result for per-table files and page/fragment table counts. Decide whether callout fragment
-   recovery belongs in this parser or should wait for an ETL FK.
-6. **Validate the directory as an artifact.** Assert stable reruns, row counts against direct SQL,
-   correct quoting in Numbers/Excel-like inputs, no reads outside the DB, and useful failure behavior
-   without leaving a partially convincing directory.
-7. **Only then consider publication.** A later issue can define release/version URL layout, Pages
-   deployment, retention, compression, caching, and large-scale JSON. None belongs in the initial local
-   pass.
+1. **Run a DB-only feasibility/census pass.** Write focused queries and small probes for proposed
+   columns, product-spec key coverage, page table shapes, section joins, and callout attribution. Confirm
+   the current runtime artifact contains only the expected Docusaurus prose source.
+2. **Generate a representative local sample.** Materialize enough of the strawman directory to inspect
+   in Numbers/Excel, GitHub/editor renderers, `awk`, and—where relevant—RouterOS `:deserialize`. The
+   sample is there to refine scope and file shapes, not to declare them stable contracts.
+3. **Refine the small useful core.** Keep direct/normalized summaries, the combined product catalog,
+   per-product sparse specs, and page/section audit metrics. Collapse redundant product views. Include
+   per-page table files only if the census shows they can be produced with small, trustworthy logic.
+4. **Build one reusable export path.** Add `export <directory>` before MCP startup, reuse normal DB
+   resolution/readiness and existing device-export query logic, and share deterministic TSV/TOML/path
+   helpers. For this local phase, overwriting the command's previously generated output is the simplest
+   working assumption; safe replacement behavior needs definition before implementation.
+5. **Turn measured schema gaps into focused follow-ups where useful.** Section FKs and generic table
+   storage should gain issues only when the probes provide counts/examples and a clearer scope. Link the
+   resulting work back here and to B-0007 where table findings affect device-capability treatment.
+6. **Validate the directory as an artifact.** Compare row counts with direct SQL, check stable reruns,
+   ensure no reads escape the DB boundary, and avoid leaving a partially convincing directory on error.
+7. **Consider publication later.** Release/version URL layout, Pages deployment, retention,
+   compression, caching, and large-scale JSON depend on the usefulness of the local output and remain
+   intentionally unspecified.
 
-# Current lean
+# Working direction
 
-Proceed with a local DB-only exporter, but treat it as an **artifact audit with honest omissions**, not a
-promise that every strawman column already exists. Start with the normalized TSVs and scalar metrics;
-include the generic Markdown-table pass only if it remains small and deterministic against the Markdown
-stored in SQLite. Do not add cache fallbacks to fill holes.
+Proceed by using the export idea to **measure and expose** the current artifact, not by designing every
+future schema now. Product and page/table exploration are the highest-value areas. Commands get a KISS
+summary; the known video provenance gap stays with #21; mistaken device page-byte counts are gone.
 
-Before implementation, promote the settled first-pass file/column contract to a GitHub issue and cite
-this briefing. Schema additions uncovered here should be separate, explicit follow-ups unless one is
-strictly required for a coherent initial export.
+The first useful output should favor honest omissions and coverage summaries over cache fallbacks or
+complex re-parsing hidden inside `export`. At the same time, the exporter should produce enough concrete
+files—especially per-product specs and, if feasible, generic page tables—to make the next schema/MCP/TUI
+questions visible to humans using ordinary tools.
 
-# Open questions
+# Feasibility questions to answer next
 
-- Is `transcript_type` meant to describe provenance (automatic/manual/language) or output layout
-  (chaptered/full-video)? Only the latter is derivable today.
-- Should page table exports include only pipe-style Markdown tables, or also raw HTML/MDX tables
-  retained in page text?
-- For device `byte_count`, is the desired unit the unavailable raw source-page body, or the stored
-  normalized `specs_json` payload?
-- Should legacy Confluence DBs export a reduced, clearly identified dataset, or should generic page-table
-  exports require current Docusaurus provenance?
-- Is an existing non-empty destination an error, an atomic replacement, or an idempotent overwrite?
+- What is the full census of pipe, HTML, MDX, malformed, and duplicate-fragment table shapes in the
+  current Docusaurus DB, and how much code is needed to export all of them honestly?
+- Can properties and callouts be mapped uniquely to `sections` from current stored data, and how often
+  do they fail or become ambiguous?
+- Which product spec keys have enough coverage or audit value for `products.tsv`, and are the two
+  alternate slug-keyed files useful after the combined identifiers are present?
+- Which TSV encoding strategy actually works across the intended spreadsheet, GitHub/editor, Unix, and
+  RouterOS consumers? Would sidecar text files remove the hardest incompatibilities?
+- When overwriting an existing destination, which paths are safely command-owned and how can replacement
+  avoid stale files or partial output without making CI/versioned publication part of this scope?

--- a/briefings/B-0022-runtime-sqlite-dataset-exports.md
+++ b/briefings/B-0022-runtime-sqlite-dataset-exports.md
@@ -51,6 +51,11 @@ rosetta actually ships:
 This complements B-0003's decision not to expose a general `run_sql` MCP tool. It is a bounded,
 read-only set of bulk datasets, not arbitrary SQL execution in an agent-facing request path.
 
+The audit premise has already paid for itself. Working through the export column by column surfaced
+three defects in shipped data that no current test or surface reports: 165 properties destroyed on
+insert, per-version command counts that silently reflect one architecture, and 501 properties whose
+recorded section cannot exist as a row. Those are findings about rosetta's data, not about file formats.
+
 # Hard boundary: the shipped DB is the source
 
 At runtime, `export` may read only the database selected through rosetta's normal DB resolution. It may
@@ -70,9 +75,19 @@ An unavailable column should be omitted or explicitly documented as unavailable.
 cache would defeat the audit.
 
 The target is the current Docusaurus-built runtime artifact. The exporter does not need a reduced
-compatibility mode for historical Confluence release databases. If current extraction leaves
-Confluence-sourced page rows in the release DB, that is a data-integrity finding to surface rather than
-an alternate export contract to design around.
+compatibility mode for historical Confluence release databases.
+
+The Confluence-contamination worry is settled and can stop being carried as a risk. `extract-docusaurus.ts`
+deletes and rebuilds `pages`/`sections`/`properties`/`callouts` on every run, and a fresh build yields
+365 pages all under `manual.mikrotik.com` with zero `help.mikrotik.com` rows. Prose sources do not mix.
+
+There is a **developer-environment trap** worth stating plainly, because it invalidates casual grounding:
+the repo-root `ros-help.db` is not the artifact this briefing targets. It is the v0.10.0 **Confluence**
+corpus (321 pages, all `help.mikrotik.com`), it is held open by running MCP servers, and the in-session
+`routeros_*` MCP tools answer from it. Any census of pages, sections, properties, callouts, or tables
+must be run against a freshly built Docusaurus DB at a scratch `DB_PATH`, or it measures the wrong
+corpus. Product, video, changelog, and command tables do not come from Docusaurus prose and are the same
+in both.
 
 # Working export families and current feasibility
 
@@ -80,6 +95,9 @@ This is a feasibility inventory, not a final filename or column contract. Direct
 generally retain their SQLite names: the correspondence makes each export easier to trace and acts as a
 loose column-name audit. Derived or joined values still need names chosen for clarity in the file where
 they appear; matching SQL mechanically is less important than accurately describing the value.
+
+Counts below come from a `--from-cache` Docusaurus build (365 pages, 2,931 sections, 4,410 properties,
+945 callouts) for prose, and from the current catalog/command/video tables for the rest.
 
 ## Changelog
 
@@ -92,8 +110,10 @@ export context shows a good reason to rename them.
 
 `videos.tsv` is mostly direct. `videos` stores title, upload date, YouTube ID/URL, duration, view/like
 counts, and whether chapters exist. Joining `video_segments` provides segment/chapter counts plus
-transcript word and UTF-8 byte counts. Full transcript text is also in the DB, so a later
-`videos/<video_id>/` detail directory could remain within the DB-only constraint.
+transcript word and UTF-8 byte counts. Every video has at least one segment (538 videos, 1,953 segments;
+232 chaptered, 306 without chapters carrying a single whole-video segment), so the join never drops a row.
+Full transcript text is also in the DB, so a later `videos/<video_id>/` detail directory could remain
+within the DB-only constraint.
 
 The schema does not yet retain transcript provenance such as automatic vs. author-provided. That is
 already tracked by [#21](https://github.com/tikoci/rosetta/issues/21), including the proposed
@@ -107,24 +127,41 @@ The product data is better considered one family than a collection of unrelated 
 `devices`, `hardware_catalog`, `device_aliases`, and `hardware_catalog.specs_json` collectively represent
 rosetta's product knowledge across the matrix, `/hardware`, and www product sources.
 
+Coverage is now measured rather than assumed. Of 255 `hardware_catalog` rows: 247 have `specs_json`, 242
+have a `/hardware` slug, 209 have a www code, and only 156 link to a matrix `devices` row. So roughly
+**39% of catalog products have no matrix backing** — a `products.tsv` keyed on the catalog is strictly
+richer than re-exporting `devices`, and the matrix-presence column is a real audit signal, not a
+formality.
+
+`specs_json` holds **142 distinct keys** with a steep coverage curve: a head of keys at 74–85%
+(`Product code`, `Suggested price`, `MTBF`, `Max power consumption`, `Storage type`/`size`, `CPU`,
+`CPU core count`, `Architecture`, `Size of RAM`, `RouterOS license`) and a long sparse tail. That head
+is the answer to "which specs belong in the summary" — it is a coverage cliff, not a judgement call.
+
+One shape problem the export must decide rather than inherit: `specs_json` **mixes provenance metadata
+into the spec namespace**. `_hardware_title` (98%), `_www_title` (85%), and `_www_tagline` (85%) are
+underscore-prefixed internal fields sitting alongside genuine product specs. A naive vertical expansion
+would present them to a spreadsheet user as if they were specs. Either the exporter filters the
+underscore prefix (and the convention becomes load-bearing), or ETL should separate them.
+
 Likely useful views to probe are:
 
 - **`products/products.tsv`** — one row per `hardware_catalog.rosetta_device_id`, including source
   identities/slugs, display name/category/lifecycle, matrix presence and common matrix fields, alias
-  count, spec count, and a deliberately small set of high-coverage/useful www specs such as CPU,
-  architecture, RAM, storage, switch chip, power, and port counts. This is the closest DB-only successor
-  to the manually produced `hardware-www-matrix.csv`, but should be a richer combined catalog rather
-  than merely re-exporting `devices`.
+  count, spec count, and the measured high-coverage spec head above. This is the closest DB-only
+  successor to the manually produced `hardware-www-matrix.csv`.
 - **`products/matrix.tsv`** — the normalized matrix-backed fields currently exposed as
-  `rosetta://datasets/devices.csv`, if retaining the narrower source-shaped view proves useful beside
-  the combined catalog.
-- **`products/by-hardware-slug.tsv` and `products/by-www-slug.tsv`** — alternate flat views keyed by
-  `source_hardware_slug` or `source_www_code`, with cross-links and the same useful/common columns.
-  These may overlap enough with `products.tsv` that the feasibility pass can simplify them rather than
-  committing to three nearly identical tables.
+  `rosetta://datasets/devices.csv`. `exportDevicesCsv()` already exists and is the obvious query source
+  to reuse, changing only the serialization.
 - **`products/<rosetta_device_id>/specs.tsv`** — a vertical `name`/`value` expansion of every stored
   `specs_json` member for that product, optionally accompanied by aliases and source identities. This
-  preserves the sparse long tail without turning `products.tsv` into hundreds of mostly empty columns.
+  preserves the 142-key sparse tail without turning `products.tsv` into mostly-empty columns.
+
+The two alternate slug-keyed views (`by-hardware-slug.tsv`, `by-www-slug.tsv`) should be **dropped**.
+Both `source_hardware_slug` and `source_www_code` are already columns on `products.tsv`, and both are
+near-unique per product, so the alternate files would be the same rows in a different sort order minus
+the products lacking that source. A spreadsheet user sorts a column; they do not need a third file to do
+it. If a genuine need appears later it is a trivial re-emit.
 
 The earlier page-byte idea was mistaken and is dropped. The catalog stores normalized www facts, not
 raw `/hardware` or www page bodies. Useful size-like audit signals here are row counts, alias counts,
@@ -132,97 +169,185 @@ raw `/hardware` or www page bodies. Useful size-like audit signals here are row 
 
 ## Properties and section identity
 
-`properties.tsv` can join `properties` to `pages` for `slug`/`rosetta_id`, numeric page ID, title, URL,
-and the stored property fields. `properties.section` records the nearest heading text, but it does not
-FK directly to `sections.id` or store the exact `anchor_id`. A heading-text join may be ambiguous when a
-page repeats a heading.
+This was the briefing's "measure it before declaring a migration" item. It has been measured, and the
+finding is stronger than expected: **`properties.section` storing heading text rather than a section
+identity is actively destroying data in the shipped artifact.**
 
-That looks like a real schema weakness, but the useful next step here is to measure it rather than
-declare a migration from the briefing: count properties with no section, repeated headings within a
-page, and rows that cannot map uniquely to a stored section. If the materiality is confirmed, a focused
-schema issue can use those results and examples to scope a `section_id`/fragment relationship.
+Of 4,575 properties parsed from the current corpus, only **4,410 are stored**. The
+`UNIQUE(page_id, name, section)` constraint combined with `INSERT OR IGNORE` silently discards **165
+rows** — a property whose page has two same-named headings collapses into whichever came first. Real
+examples: `ppp-aaa` loses `comment`, `local-address`, `name`, and `remote-address` because the page has
+several `Properties` headings; `dot1x` loses `interface` under a repeated `Server`. Nothing reports this.
+
+Of the 4,410 that survive, joining `properties.section` to `sections.heading` within a page gives:
+
+| Result | Rows | Share |
+|---|---|---|
+| Unique match | 3,191 | 72% |
+| Ambiguous (2–8 candidate sections) | 718 | 16% |
+| No matching section row at all | 501 | 11% |
+
+The two failure modes have distinct, already-understood causes in `extract-docusaurus.ts`:
+
+- **The 501 "no match" are not missing data — they are a level mismatch.** `parseProperties` tracks
+  `currentSection` from `#{1,6}` headings; `parseSections` only mints section rows for `#{1,3}`,
+  deliberately folding deeper headings into the enclosing section's text. So every property under an
+  h4–h6 heading records a `section` string that cannot exist in `sections`. The corpus has 817 h4–h6
+  headings against 4,098 h1–h3, and a sample of "no match" values (`Certificate template properties`,
+  `Advanced Monitor`, `Port Resources/Usage`, …) confirmed all were h4–h6.
+- **The 718 ambiguous are a discarded disambiguation.** `parseSections` already resolves duplicate
+  headings into unique `anchor_id`s (`foo`, `foo-1`, `foo-2`); `properties` stores the raw heading text
+  and throws that away. The corpus has 86 page/heading pairs that repeat, worst offenders being
+  `layer2-misconfiguration` (`Problem`/`Solution`/`Symptoms`, 18× each) and `user-manager`/`ipsec`
+  (`Properties`, 8× each).
+
+This reframes the fix. It is not a speculative schema migration justified by export convenience: both
+parsers already walk the same Markdown, line by line, in the same extraction pass. Correlating a
+property to the section whose line range contains it is local work, and `section_id` then makes the
+`UNIQUE` constraint correct instead of lossy. The export is what made the loss visible; the loss would
+be worth fixing even if the export were abandoned.
+
+The honest interim behavior for `properties.tsv` is to emit `section` as stored plus a resolved
+`section_anchor` where the join is unique and empty where it is not, so the file shows the 28% rather
+than papering over it.
 
 ## Pages, fragments, and generic tables
 
 `pages.tsv` can provide two kinds of row in one pivot-like audit view:
 
 - a page rollup with `rosetta_id`, `slug`, `title`, `url`, stored `word_count`, derived text/code byte
-  counts, section count, and any table counts the probe can establish; and
+  counts, section count, and table counts; and
 - one row per `sections` record with `anchor_id`, `heading`, `level`, `sort_order`, `word_count`, byte
   counts, and table/table-row counts for that fragment.
 
-The scalar page/section metrics are straightforward. Generic table metrics are the uncertain part:
-the current Docusaurus extractor stores raw Markdown in `pages.text` and section Markdown in
-`sections.text`, but does not store generic tables as structured rows. An export-time parser would need
-to scan the DB-resident Markdown, distinguish pipe tables from raw HTML/MDX forms, associate each table
-with a page and nearest fragment, handle multiple tables under one fragment, and identify malformed or
-unsupported shapes without guessing.
+The scalar metrics are straightforward and immediately useful as MCP/TUI evidence. Pages average 13KB of
+text but run to **153KB** (`bridging-and-switching`, 21,626 words, 50 sections); the ten largest pages
+are 17.6% of all page bytes. Sections are far better behaved: p50 730B, p90 3.3KB, p99 10.7KB, max 34KB.
+That ~200× page-level spread against a ~15× section-level spread is a concrete argument that sections,
+not pages, are the sane retrieval unit, and that any page-level `limit` is really a truncation policy.
+The census also found **129 empty sections** (4.4%) — headings with no body — which retrieval currently
+treats as real fragments.
 
-Before making that parser a permanent part of `export`, a focused DB-only census should answer:
+The generic-table question is now answered, and it is not the hard part the briefing assumed:
 
-- how many pages/fragments contain pipe-style, HTML, or MDX-like table shapes;
-- how many tables parse with a simple shared rule and how many are exceptional;
-- how often a fragment contains multiple tables or filename collisions;
-- which headers/shapes recur, especially property-like and device-keyed tables; and
-- how much parsing logic would duplicate or diverge from `extract-docusaurus.ts`.
+| Measure | Result |
+|---|---|
+| Pipe tables | 855 across 180/365 pages, 8,278 data rows |
+| HTML `<table>` elements | **0** |
+| Genuinely ragged tables | **14** (1.6%) |
+| Empty-header (layout) tables | 28 |
+| Two-column tables | 672 (79%) |
+| Property-like header (`Property`/`Parameter` …) | **596 (70%)** |
+| Non-property tables | **259** |
+| Fragments containing >1 table | 85 / 704 (12%) |
 
-If the common case stays small and deterministic, emit each table as
-`pages/<page-slug>/<fragment>[--N].tsv` and feed the same parse result into `pages.tsv` counts. If doing
-that honestly requires complex source-specific logic, stopping at the census is itself a useful result:
-it suggests generic tables or a parsed-table JSON representation may belong in ETL/core data rather
-than inside the exporter.
+Three conclusions follow, two of which cut against the original framing:
 
-This is more than an export implementation detail. A generic stored-table representation could retain
-page/section context, headers, rows, ordinals, and perhaps raw source; `routeros_get_page` could then
-reconstruct or return tables structurally. Property extraction might eventually become a classification
-or query over that generic table corpus instead of the only special table parser. The device-specific
-tables in B-0007 may still deserve normalized domain schema, but seeing the complete table inventory as
-files is a practical precursor to deciding which tables warrant that promotion.
+1. **There is no HTML/MDX table problem.** The worry about distinguishing pipe tables from "raw HTML/MDX
+   forms" was unfounded: the corpus contains zero `<table>` elements. The shape is uniform pipe syntax,
+   overwhelmingly two columns, and 98.4% of tables are internally consistent. A parser is small.
+2. **But 70% of tables are already `properties`.** The generic table corpus is mostly a less-structured
+   copy of a table rosetta already extracts. Only **259 tables carry information not already modeled**.
+   That materially weakens "export every table as a file" and strengthens the narrower question: what is
+   in those 259?
+3. **Naive parsing is a trap, and the fix is not exported.** RouterOS enum values pervade these tables as
+   escaped pipes (`*md5 \| sha1 \| sha256*`), and **1,422 cells contain a literal `|` after unescaping**.
+   A `line.split("|")` implementation reports 374 "ragged" tables — 44% — that are simply wrong; the true
+   figure using escape-aware splitting is 14. `extract-docusaurus.ts` already has correct
+   `splitTableRow`, but it is **module-private and not exported**. Any second implementation will
+   re-introduce this bug, and it is the same reason a downstream `awk -F'|'` consumer would silently
+   corrupt data.
+
+So the useful next probe is not "can we parse tables" but "are the 259 non-property tables worth
+promoting". Emitting per-fragment table files for the 70% that duplicate `properties` would add files
+without adding knowledge.
+
+This still matters beyond the exporter. A generic stored-table representation could retain page/section
+context, headers, rows, ordinals, and perhaps raw source; `routeros_get_page` could then return tables
+structurally. Property extraction might eventually become a classification over that generic corpus
+rather than the only special table parser — the 70% overlap is evidence that this is the *same* corpus
+viewed twice, not two corpora. The device-specific tables in B-0007 may still deserve normalized domain
+schema.
 
 ## Callouts
 
 `callouts.tsv` directly supports page, type, order, and text, but `callouts` has no section/fragment FK.
-Re-parsing `pages.text` could recover heading context for current Docusaurus Markdown, but that would
-duplicate extraction logic just as generic table parsing would. The feasibility probe should measure
-how reliably stored callout content maps to a unique `sections` row. Together with the properties probe,
-this gives concrete scope to the broader finding that page subsections are not consistently represented
-as relationships in the schema.
+
+The briefing suggested re-parsing `pages.text` to recover heading context, and worried it would duplicate
+extraction logic. That framing was wrong in a useful way: `parseProperties` **already tracks
+`currentSection`** while walking the same Markdown. `parseCallouts` simply does not — it tracks a fence
+stack and sort order and never looks at headings. So callout section attribution is not a re-parse
+problem or an export problem; it is a field the extractor is positioned to record and does not. That
+belongs with the `section_id` work above, not in the exporter.
+
+`callouts.content` is also the **only** multiline scalar in the export set — see below.
 
 ## Commands
 
-Keep this deliberately shallow. `commands-by-version.tsv` only needs to round out the export with a
-summary of data already present: RouterOS version, total distinct path count, and simple `dir`/`cmd`/`arg`
-counts where the existing tables support them reliably. Versions must use the existing numeric/beta/RC
-comparator rather than SQL lexical order.
+The original instinct — keep this shallow, just round out the export — does not survive contact with the
+data. `commands-by-version.tsv` as specified would be actively misleading.
 
-Per-architecture counts and a redesign of `schema_node_presence` are not goals here. CLI Reference,
-multi-architecture deep-inspect, and command-schema work already have their own active research/issues;
-this briefing does not need to pull them forward merely to make the export more symmetrical.
+The direct part is fine: `commands.type` gives `dir`/`cmd`/`arg` counts straight (550 / 5,097 / 34,948 of
+40,595), so those columns need only a definition, not new logic.
 
-# Schema/ETL questions this audit is surfacing
+The version dimension is the problem. `command_versions` has PK `(command_path, ros_version)` — **no
+architecture column** — while `ros_versions` has PK `(version, arch)` and holds both `x86` and `arm64`
+rows for **17 versions** (7.20.8 through 7.24rc1). `extract-commands.ts` runs
+`DELETE FROM command_versions WHERE ros_version = ?` and then re-inserts. That is **last-writer-wins**,
+not a merge: for those 17 versions the stored path set reflects whichever architecture was extracted
+last, and which one that was is not recorded anywhere. A version→path-count column would present that as
+a fact. This is worse than the briefing's "not durably representable today" — the data is not merely
+un-exportable per-arch, it is silently one arch wearing the label of the version.
 
-The valuable questions are still directional and evidence-seeking:
+Two further traps sit next to it:
 
-1. **Section identity:** how material are the missing/ambiguous property and callout relationships to
-   `sections`, and would a direct `section_id` or stable fragment identity solve both cleanly?
-2. **Generic table storage:** are DB-resident Markdown tables simple enough to parse only for export, or
-   would storing a generic structured representation in ETL unlock better auditing plus MCP/TUI
-   behavior? How would that generic layer coexist with domain-specific promotion for properties and
-   device-capability tables?
-3. **Product catalog shape:** which `specs_json` keys are common/useful enough for the combined summary,
-   and which belong only in per-product key/value files? Do alternate hardware/www keyed views add real
-   audit value beyond identifiers already present in `products.tsv`?
-4. **Artifact readability:** which combination of summary TSVs, per-item TSVs, and non-tabular sidecars
-   makes the DB easiest to inspect without hiding sparse or multiline content?
+- `schema_nodes` and `schema_node_presence` are **empty** (0 rows) in the current local DB.
+  `release.yml` only runs `extract-all-versions.ts` when the `full_versions` input is set, otherwise it
+  runs `extract-commands.ts`. So whether these tables ship populated is a per-release property. An export
+  that reads them will produce an empty file for some releases and data for others, with no explanation.
+  The manifest should record which path built the DB. (Whether published release assets actually ship
+  them populated is unverified here and should be checked against a real release asset, not inferred
+  from this local file.)
+- The version comparator warning is real and easy to underestimate. Preparing this pass, a
+  `MIN/MAX(version)` query reported x86 as spanning only 7.1.1–**7.9.2**, which is lexical nonsense —
+  `7.9.2` sorts above `7.24rc1` — and led to a wrong conclusion about arch coverage until it was caught.
+  Any exporter touching versions must use the existing comparator, and the census scripts should too.
 
-Transcript provenance is also a real schema gap, but it is already scoped in #21 and is not a question
-this briefing needs to answer. Command architecture is intentionally left to the existing command/CLI
-Reference work.
+The right move is to keep commands shallow by **narrowing** rather than by summarizing loosely: emit the
+`dir`/`cmd`/`arg` totals and the version list, and either omit per-version path counts or carry them only
+with an explicit `arch_unknown` marker until `command_versions` can distinguish. Per-architecture command
+work stays with the existing command/CLI Reference issues; this briefing should hand them a measured bug
+rather than pull their scope forward.
+
+# Schema/ETL findings this audit produced
+
+The directional questions have largely resolved into findings. Ordered by confidence and materiality:
+
+1. **Confirmed data loss — properties.** 165 of 4,575 parsed properties are silently dropped by
+   `UNIQUE(page_id, name, section)` + `INSERT OR IGNORE`, because `section` is heading text. Fixing
+   section identity fixes the loss. This deserves an issue on its own merits, independent of `export`.
+2. **Confirmed integrity bug — command_versions.** Arch-blind PK plus delete-then-reinsert makes 17
+   versions' path sets last-writer-wins between x86 and arm64. Deserves an issue; likely belongs to the
+   existing command/CLI Reference thread rather than a new one.
+3. **Confirmed design gap — section identity.** 28% of properties cannot be uniquely resolved to a
+   section (11% because sections stop at h3 while properties track to h6; 16% because `anchor_id`
+   disambiguation exists but is discarded). Callouts have no section attribution at all despite the
+   extractor already tracking it for properties. One `section_id` change addresses all three.
+4. **Resolved — generic tables are easy to parse but mostly redundant.** 855 tables, 0 HTML, 1.6%
+   ragged, but 70% already modeled as `properties`. The open question shrinks to the 259 non-property
+   tables. `splitTableRow` needs exporting before anything else parses a table.
+5. **Resolved — product spec head.** 142 keys, coverage cliff at ~74%, and `specs_json` mixes
+   underscore-prefixed provenance with real specs. Alternate slug-keyed views are redundant.
+6. **Resolved — TSV is safe.** See below.
+7. **Open — release-conditional tables.** `schema_nodes`/`schema_node_presence` populated only on
+   `full_versions` releases; the manifest should say which.
+
+Transcript provenance is a real gap already scoped in [#21](https://github.com/tikoci/rosetta/issues/21).
 
 # Strawman local directory
 
-The structure below is a working aid for the feasibility pass, not a promise that every alternate view
-survives unchanged:
+The structure below reflects the census: the two slug-keyed product views are gone, and per-fragment
+table files are held back pending the 259-table question.
 
 ```text
 rosetta-datasets/
@@ -231,100 +356,105 @@ rosetta-datasets/
 ├── videos.tsv
 ├── properties.tsv
 ├── pages.tsv
-├── commands-by-version.tsv
+├── commands.tsv
 ├── callouts.tsv
-├── products/
-│   ├── products.tsv
-│   ├── matrix.tsv
-│   ├── by-hardware-slug.tsv
-│   ├── by-www-slug.tsv
-│   └── <rosetta-device-id>/
-│       └── specs.tsv
-└── pages/
-    └── <page-slug>/
-        ├── <fragment>.tsv
-        └── <fragment>--2.tsv
+└── products/
+    ├── products.tsv
+    ├── matrix.tsv
+    └── <rosetta-device-id>/
+        └── specs.tsv
 ```
 
 `manifest.toml` can carry richer structure than a TSV: database/package/schema/release provenance from
 `db_meta`, generated file names and row counts, coverage summaries, and known omitted/unavailable
-fields. It is also a natural place for the table/section/product census results that do not fit one flat
-row shape. JSON remains a possible future bulk dataset format, not a requirement of this local pass.
+fields. It is the natural home for the census results that do not fit one flat row shape, and for the
+honest disclosures this pass has identified — the properties that lost their section, whether the DB was
+built with `full_versions`, and which architecture claim cannot be made. JSON remains a possible future
+bulk dataset format, not a requirement of this local pass.
 
 Subdirectories are not restricted to TSV forever. For example, a later video detail export could use
-`transcript.txt` plus `metadata.toml`; keeping multiline prose out of a summary table may make both the
-table and the detail easier to consume.
+`transcript.txt` plus `metadata.toml`.
 
 # TSV as the working tabular format
 
-TSV is a reasonable default to test. GitHub and editor plugins render it well, spreadsheets commonly
-import it, and it is visually/physically lighter than comma-separated output for data whose ordinary
-values contain commas. It also resembles direct SQL query output and is friendlier to token-based text
-inspection when cells remain simple.
+TSV is a reasonable default, and the consumer-mismatch worry is now mostly retired by measurement rather
+than by testing a matrix.
 
-There is one important consumer mismatch to investigate rather than hand-wave: spreadsheet-compatible
-CSV-style quoting with a tab delimiter can preserve literal tabs/newlines, but plain `awk -F '\t'` and
-RouterOS `:deserialize` do not provide the same quote-aware record parsing. Quoted multiline cells also
-break the useful property that one physical line equals one record.
+**The corpus contains no tabs.** Zero across `properties.description`, `properties.name`,
+`changelogs.description`, `callouts.content`, `pages.title`, `video_segments.transcript`, and all 8,278
+Markdown table cells. The hope that ETL avoids tabs is not a hope; it is a measured property. So plain
+tab-delimited output with no quoting is lossless for every scalar in the export set, and stays parseable
+by `awk -F '\t'` and RouterOS `:deserialize`.
 
-The feasibility pass should therefore test a small consumer matrix and choose intentionally among:
+**One exception:** `callouts.content` contains newlines in **163 of 945 rows** (17%). That is the whole
+of the multiline problem, and it is confined to one column of one file. Rather than adopting quote-aware
+TSV corpus-wide — which would cost every simple consumer the one-line-equals-one-record property to
+serve 163 rows — the proportionate options are a documented reversible escape for that column, or moving
+callout bodies to sidecars while `callouts.tsv` keeps type/order/page and a reference. The earlier
+three-way consumer matrix does not need running; it only needs deciding for this one column.
 
-- keeping summary TSV cells single-line and free of literal tabs, with a documented reversible escape
-  for exceptional characters;
-- using quote-aware TSV for exact multiline values and accepting that simple `awk`/RouterOS consumers
-  need a stronger parser; or
-- moving multiline/raw content into per-item `.txt`/`.md` sidecars while TSVs retain summaries and
-  references.
+The serializer still needs defined behavior if a tab ever appears, since "measured absent today" is not
+"impossible tomorrow" — but that is a guard, not a design constraint.
 
 Whatever shape wins should be UTF-8 with LF endings, a header row, stable row/column ordering, explicit
 SQL `NULL` handling, and a single shared word-count rule. Raw slugs and fragments stay in columns even
-when filesystem-safe names must be sanitized. The hope that ETL normally avoids tabs is useful, but the
-serializer still needs defined behavior when a source does contain one.
+when filesystem-safe names must be sanitized.
 
-# High-level plan of attack
-
-1. **Run a DB-only feasibility/census pass.** Write focused queries and small probes for proposed
-   columns, product-spec key coverage, page table shapes, section joins, and callout attribution. Confirm
-   the current runtime artifact contains only the expected Docusaurus prose source.
-2. **Generate a representative local sample.** Materialize enough of the strawman directory to inspect
-   in Numbers/Excel, GitHub/editor renderers, `awk`, and—where relevant—RouterOS `:deserialize`. The
-   sample is there to refine scope and file shapes, not to declare them stable contracts.
-3. **Refine the small useful core.** Keep direct/normalized summaries, the combined product catalog,
-   per-product sparse specs, and page/section audit metrics. Collapse redundant product views. Include
-   per-page table files only if the census shows they can be produced with small, trustworthy logic.
-4. **Build one reusable export path.** Add `export <directory>` before MCP startup, reuse normal DB
-   resolution/readiness and existing device-export query logic, and share deterministic TSV/TOML/path
-   helpers. For this local phase, overwriting the command's previously generated output is the simplest
-   working assumption; safe replacement behavior needs definition before implementation.
-5. **Turn measured schema gaps into focused follow-ups where useful.** Section FKs and generic table
-   storage should gain issues only when the probes provide counts/examples and a clearer scope. Link the
-   resulting work back here and to B-0007 where table findings affect device-capability treatment.
-6. **Validate the directory as an artifact.** Compare row counts with direct SQL, check stable reruns,
-   ensure no reads escape the DB boundary, and avoid leaving a partially convincing directory on error.
-7. **Consider publication later.** Release/version URL layout, Pages deployment, retention,
-   compression, caching, and large-scale JSON depend on the usefulness of the local output and remain
-   intentionally unspecified.
+Note the corpus does contain 1,422 table cells with literal `|`. That does not affect TSV output, but it
+is why any consumer or second implementation that splits Markdown tables on `|` is wrong.
 
 # Working direction
 
 Proceed by using the export idea to **measure and expose** the current artifact, not by designing every
-future schema now. Product and page/table exploration are the highest-value areas. Commands get a KISS
-summary; the known video provenance gap stays with #21; mistaken device page-byte counts are gone.
+future schema now. The census has done much of that already and shifted the weight: the interesting
+output of this briefing is turning out to be the schema findings, with the files as the instrument that
+produced them.
+
+Two course corrections against the earlier draft:
+
+- **Products got simpler** (three near-identical views collapse to one catalog plus per-product specs).
+- **Commands got harder** (the "KISS summary" would have shipped an arch-mixed number as a fact).
 
 The first useful output should favor honest omissions and coverage summaries over cache fallbacks or
-complex re-parsing hidden inside `export`. At the same time, the exporter should produce enough concrete
-files—especially per-product specs and, if feasible, generic page tables—to make the next schema/MCP/TUI
-questions visible to humans using ordinary tools.
+complex re-parsing hidden inside `export`. Schema improvement should not block getting files — but the
+properties data loss is now confirmed rather than suspected, and it should not wait on `export` either.
 
-# Feasibility questions to answer next
+# Next steps
 
-- What is the full census of pipe, HTML, MDX, malformed, and duplicate-fragment table shapes in the
-  current Docusaurus DB, and how much code is needed to export all of them honestly?
-- Can properties and callouts be mapped uniquely to `sections` from current stored data, and how often
-  do they fail or become ambiguous?
-- Which product spec keys have enough coverage or audit value for `products.tsv`, and are the two
-  alternate slug-keyed files useful after the combined identifiers are present?
-- Which TSV encoding strategy actually works across the intended spreadsheet, GitHub/editor, Unix, and
-  RouterOS consumers? Would sidecar text files remove the hardest incompatibilities?
-- When overwriting an existing destination, which paths are safely command-owned and how can replacement
-  avoid stale files or partial output without making CI/versioned publication part of this scope?
+Session-scoped items, each independently useful. None require adding `export` to core code.
+
+1. **File the properties data-loss issue.** The 165-row loss, the 72/16/11 split, and the h3-vs-h6 and
+   `anchor_id`-discard causes are all measured with examples. Scope: carry `section_id` on `properties`
+   and `callouts` by correlating line ranges in the existing single parse pass; make `UNIQUE` use
+   `section_id`. Cite this briefing. Do this first — it is a shipped-data bug, not export scope.
+2. **File the `command_versions` arch issue** against the existing command/CLI Reference thread, with
+   the 17 dual-arch versions and the delete-then-reinsert mechanism. Decide there whether the PK gains
+   `arch` or extraction refuses to overwrite across arches.
+3. **Export `splitTableRow`** from `extract-docusaurus.ts` (plus a test asserting escaped-pipe handling).
+   One-line change that prevents the 44%-wrong second implementation this pass already stumbled into, and a
+   prerequisite for any table census script living in the repo.
+4. **Census the 259 non-property tables** — the one table question still open. Group them by header
+   shape and page, and decide whether they are (a) device/capability tables belonging to B-0007, (b)
+   worth a generic stored-table representation, or (c) noise. This is the input to the biggest schema
+   decision in the briefing and is a scripting task, not a code change.
+5. **Prototype two files throwaway** — `products.tsv` and `pages.tsv` — against a scratch Docusaurus DB,
+   and open them in Numbers and GitHub. These are the two with real shape questions (spec head selection;
+   page-vs-section rows in one file). Keep it out of `src/`; the point is to answer the layout question
+   before any `export` command exists.
+
+Deferred deliberately: publication/Pages layout, retention, compression, JSON, and overwrite/replacement
+semantics. None of them can be decided well before the file set stabilizes.
+
+# Questions for the next pass
+
+- **Is `products.tsv` keyed correctly?** It assumes `hardware_catalog.rosetta_device_id` is the product
+  identity, which makes 99 matrix-less products first-class rows. If the intended audience thinks in
+  matrix terms, that is 39% surprising rows; if they think in catalog terms, `devices` is the surprising
+  view. This drives the whole family's shape.
+- **Do the 129 empty sections and the 153KB page belong in `pages.tsv` as-is,** or is the census
+  actually pointing at a retrieval-unit issue worth its own briefing? The size data seems more valuable
+  to MCP/TUI work than to the export, and may be escaping this briefing's scope.
+- **Is `export` still the right vehicle** if the schema findings are the main product? An honest reading
+  of this pass is that a `scripts/census.ts` would have produced findings 1–5 without shipping a user
+  surface. `export` is still worth building for the spreadsheet audience — but that is a product
+  argument, not the audit argument, and the briefing should probably say which one is load-bearing.

--- a/project-words.txt
+++ b/project-words.txt
@@ -280,6 +280,7 @@ passthroughs
 pathified
 pathify
 pathifying
+pci
 pcq
 persistable
 phy

--- a/src/eval/db-census.ts
+++ b/src/eval/db-census.ts
@@ -49,7 +49,9 @@ function splitTableRow(line: string): string[] {
     current += line[i];
   }
   cells.push(current.trim());
-  return cells.slice(1, -1);
+  if (cells[0] === "") cells.shift();
+  if (cells[cells.length - 1] === "") cells.pop();
+  return cells;
 }
 
 function provenance(): void {

--- a/src/eval/db-census.ts
+++ b/src/eval/db-census.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+
+/**
+ * DB-only census — the evidence behind the B-0022 export audit (umbrella #95).
+ *
+ * NOT a CI gate and NOT a source of truth. It re-derives, from a runtime DB alone, the
+ * measurements that produced #90–#94, so those findings can be re-checked after a fix
+ * lands rather than taken on trust from a briefing. It prints intermediate numbers on
+ * purpose: a census that only says "ok" is one a future agent can quietly satisfy.
+ *
+ * Ground against a CI-BUILT artifact, not a local rebuild. A typical repo-root
+ * ros-help.db is the stale v0.10.0 Confluence corpus and will silently answer the wrong
+ * question — that trap is #94, and it cost this audit a full wrong pass. `db_meta` is
+ * printed first so the corpus under test is never ambiguous.
+ *
+ * Usage:
+ *   DB_PATH=~/.rosetta/ros-help.db bun run src/eval/db-census.ts
+ *   DB_PATH=<scratch>/ros-current.db bun run src/eval/db-census.ts
+ */
+
+import { db } from "../db.ts";
+import { parseProperties } from "../extract-docusaurus.ts";
+
+const one = <T>(sql: string): T => Object.values(db.prepare(sql).get() as object)[0] as T;
+const rows = <T>(sql: string): T[] => db.prepare(sql).all() as T[];
+
+/**
+ * Escape-aware Markdown table row splitter.
+ *
+ * Mirrors extract-docusaurus.ts's private splitTableRow. RouterOS enum values embed
+ * escaped pipes (`*md5 \| sha1*`) in 1,420 cells, so a naive line.split("|") misreports
+ * 374 tables as ragged when the true count is 14. #92 step 1 exports the original; this
+ * copy exists only so the census can run before that lands, and should be deleted then.
+ */
+function splitTableRow(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === "\\" && line[i + 1] === "|") {
+      current += "|";
+      i++;
+      continue;
+    }
+    if (line[i] === "|") {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += line[i];
+  }
+  cells.push(current.trim());
+  return cells.slice(1, -1);
+}
+
+function provenance(): void {
+  console.log("── corpus under test ──");
+  for (const m of rows<{ key: string; value: string }>("SELECT key, value FROM db_meta ORDER BY key")) {
+    console.log(`  ${m.key.padEnd(32)} ${m.value}`);
+  }
+  const hosts = rows<{ host: string; n: number }>(`
+    SELECT CASE
+             WHEN url LIKE '%manual.mikrotik.com%' THEN 'Docusaurus'
+             WHEN url LIKE '%help.mikrotik.com%'   THEN 'Confluence (STALE — see #94)'
+             ELSE 'other' END AS host,
+           COUNT(*) AS n
+    FROM pages GROUP BY host`);
+  for (const h of hosts) console.log(`  ${"pages".padEnd(32)} ${h.n} (${h.host})`);
+}
+
+/** #90 — properties destroyed on insert, and section resolution. */
+function properties(): void {
+  console.log("\n── #90 properties: data loss + section identity ──");
+
+  let parsed = 0;
+  for (const p of rows<{ text: string }>("SELECT text FROM pages")) parsed += parseProperties(p.text).length;
+  const stored = one<number>("SELECT COUNT(*) FROM properties");
+  console.log(`  parsed ${parsed} / stored ${stored} → LOST ${parsed - stored}`);
+  console.log("    cause: UNIQUE(page_id, name, section) + INSERT OR IGNORE, section = heading TEXT");
+
+  const join = rows<{ result: string; n: number }>(`
+    WITH m AS (
+      SELECT (SELECT COUNT(*) FROM sections s WHERE s.page_id = p.page_id AND s.heading = p.section) AS n
+      FROM properties p WHERE p.section IS NOT NULL AND p.section <> ''
+    )
+    SELECT CASE WHEN n = 0 THEN 'no matching section (h4-h6: sections stop at h3)'
+                WHEN n = 1 THEN 'unique match'
+                ELSE 'ambiguous (anchor_id disambiguation discarded)' END AS result,
+           COUNT(*) AS n
+    FROM m GROUP BY result ORDER BY n DESC`);
+  for (const r of join) console.log(`  ${String(r.n).padStart(5)}  ${r.result}`);
+
+  const repeated = one<number>(
+    "SELECT COUNT(*) FROM (SELECT page_id, heading FROM sections GROUP BY page_id, heading HAVING COUNT(*) > 1)",
+  );
+  console.log(`  ${String(repeated).padStart(5)}  page/heading pairs that repeat`);
+  console.log(`  ${String(one<number>("SELECT COUNT(*) FROM callouts")).padStart(5)}  callouts, none with section attribution`);
+}
+
+/** #91 — command_versions is arch-blind. */
+function commands(): void {
+  console.log("\n── #91 commands: arch-blind version history ──");
+  for (const t of rows<{ type: string; n: number }>("SELECT type, COUNT(*) AS n FROM commands GROUP BY type ORDER BY n DESC")) {
+    console.log(`  ${String(t.n).padStart(6)}  ${t.type}`);
+  }
+  const dual = one<number>(
+    "SELECT COUNT(*) FROM (SELECT version FROM ros_versions GROUP BY version HAVING COUNT(DISTINCT arch) > 1)",
+  );
+  console.log(`  ${String(dual).padStart(6)}  versions present for BOTH arches → last-writer-wins in command_versions`);
+  console.log(`  ${String(one<number>("SELECT COUNT(DISTINCT version) FROM schema_node_presence")).padStart(6)}  distinct versions in schema_node_presence (release-pruned active head — by design)`);
+  console.log("    note: never order versions lexically — '7.9.2' > '7.24rc1' as a string.");
+}
+
+/** #92 — generic tables, and #93 — section sizing. */
+function tablesAndSizing(): void {
+  console.log("\n── #92 tables: what ETL discards ──");
+  let pipe = 0;
+  let ragged = 0;
+  let propertyLike = 0;
+  let dataRows = 0;
+  let cellsWithPipe = 0;
+  let cellsWithTab = 0;
+  let html = 0;
+  const perFragment = new Map<string, number>();
+
+  for (const p of rows<{ slug: string; text: string }>("SELECT slug, text FROM pages")) {
+    html += (p.text.match(/<table[\s>]/gi) ?? []).length;
+    const lines = p.text.split("\n");
+    let inFence = false;
+    let fragment: string | null = null;
+    for (let i = 0; i < lines.length; i++) {
+      if (/^\s*(```|~~~)/.test(lines[i])) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+      const h = lines[i].match(/^#{1,6}\s+(.+)$/);
+      if (h) {
+        fragment = h[1].trim();
+        continue;
+      }
+      const isTable = /^\s*\|.*\|\s*$/.test(lines[i]) && lines[i + 1] && /^\s*\|[\s:|-]+\|\s*$/.test(lines[i + 1]);
+      if (!isTable) continue;
+
+      const header = splitTableRow(lines[i]);
+      pipe++;
+      if (/\b(property|properties|parameter|parameters)\b/i.test(header[0] ?? "")) propertyLike++;
+      const key = `${p.slug}#${fragment ?? "(page)"}`;
+      perFragment.set(key, (perFragment.get(key) ?? 0) + 1);
+
+      let j = i + 2;
+      let isRagged = false;
+      while (j < lines.length && /^\s*\|/.test(lines[j])) {
+        const cells = splitTableRow(lines[j]);
+        if (cells.length !== header.length) isRagged = true;
+        for (const c of cells) {
+          if (c.includes("|")) cellsWithPipe++;
+          if (c.includes("\t")) cellsWithTab++;
+        }
+        dataRows++;
+        j++;
+      }
+      if (isRagged) ragged++;
+      i = j - 1;
+    }
+  }
+
+  console.log(`  ${String(pipe).padStart(5)}  pipe tables (${dataRows} data rows)`);
+  console.log(`  ${String(propertyLike).padStart(5)}  property-like → already extracted`);
+  console.log(`  ${String(pipe - propertyLike).padStart(5)}  NON-property tables → DISCARDED by ETL today`);
+  console.log(`  ${String(ragged).padStart(5)}  genuinely ragged`);
+  console.log(`  ${String(html).padStart(5)}  HTML <table> elements`);
+  console.log(`  ${String([...perFragment.values()].filter((v) => v > 1).length).padStart(5)}  fragments with >1 table (of ${perFragment.size})`);
+  console.log(`  ${String(cellsWithPipe).padStart(5)}  cells with a literal | → naive split("|") corrupts these`);
+  console.log(`  ${String(cellsWithTab).padStart(5)}  cells with a TAB → TSV safety`);
+
+  console.log("\n── #93 sizing: retrieval units ──");
+  const size = db
+    .prepare(`
+      SELECT (SELECT COUNT(*) FROM pages) AS pages,
+             (SELECT CAST(AVG(LENGTH(CAST(text AS BLOB))) AS INT) FROM pages) AS page_avg,
+             (SELECT MAX(LENGTH(CAST(text AS BLOB))) FROM pages) AS page_max,
+             (SELECT COUNT(*) FROM sections) AS sections,
+             (SELECT CAST(AVG(LENGTH(CAST(text AS BLOB))) AS INT) FROM sections) AS sec_avg,
+             (SELECT MAX(LENGTH(CAST(text AS BLOB))) FROM sections) AS sec_max,
+             (SELECT COUNT(*) FROM sections WHERE TRIM(text) = '') AS empty_sections`)
+    .get() as Record<string, number>;
+  console.log(`  pages    ${size.pages} — avg ${size.page_avg}B, max ${size.page_max}B`);
+  console.log(`  sections ${size.sections} — avg ${size.sec_avg}B, max ${size.sec_max}B`);
+  console.log(`  ${String(size.empty_sections).padStart(5)}  EMPTY sections (heading, no body)`);
+}
+
+/** TSV feasibility: tabs and newlines in columns an export would emit as cells. */
+function tsvSafety(): void {
+  console.log("\n── TSV safety: tabs/newlines in candidate scalar columns ──");
+  const checks: Array<[string, string, string]> = [
+    ["properties", "description", "tab"],
+    ["properties", "name", "tab"],
+    ["changelogs", "description", "tab"],
+    ["callouts", "content", "tab"],
+    ["video_segments", "transcript", "tab"],
+    ["callouts", "content", "newline"],
+  ];
+  for (const [table, column, kind] of checks) {
+    const ch = kind === "tab" ? 9 : 10;
+    const n = one<number>(`SELECT COUNT(*) FROM ${table} WHERE ${column} LIKE '%' || char(${ch}) || '%'`);
+    console.log(`  ${String(n).padStart(5)}  ${table}.${column} containing a ${kind}`);
+  }
+  const codeTabs = one<number>(
+    "SELECT COUNT(*) FROM pages WHERE text LIKE '%' || char(9) || '%' AND code LIKE '%' || char(9) || '%'",
+  );
+  console.log(`  ${String(codeTabs).padStart(5)}  pages with tabs inside fenced code (legitimate — never a TSV cell)`);
+}
+
+provenance();
+properties();
+commands();
+tablesAndSizing();
+tsvSafety();


### PR DESCRIPTION
## What changed

- adds and refines B-0022, grounded in the CI-built runtime SQLite artifact
- adds `src/eval/db-census.ts` to independently re-derive the findings behind issues #90–#94
- indexes the briefing and records the shared spelling

## Why

The export investigation found shipped-data and schema concerns that need independently reviewable evidence. The census makes those measurements repeatable from a runtime DB without becoming a product export surface.

## Impact

Maintainers can re-check the B-0022 evidence after fixes land with `DB_PATH=~/.rosetta/ros-help.db bun run src/eval/db-census.ts`. No user-facing export command is introduced.

Part of #95

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run lint:md`
- `bun run lint:spell`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database-only census utility that reports dataset provenance, schema coverage, command history, Markdown table statistics, and export-safety checks.
  * Added feasibility documentation for a future SQLite-based dataset export with deterministic TSV/TOML output and clear data-boundary rules.

* **Documentation**
  * Documented planned export formats, directory structure, serialization requirements, known data gaps, and deferred areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->