### PR TITLE
chore(release): promote CHANGELOG and bump to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -687,7 +687,8 @@ Initial public release.
   dev / package at `~/.rosetta/`).
 - Bun tests for the query planner + schema health.
 
-[Unreleased]: https://github.com/tikoci/rosetta/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/tikoci/rosetta/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/tikoci/rosetta/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tikoci/rosetta/compare/v0.9.3...v0.10.0
 [0.9.3]: https://github.com/tikoci/rosetta/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/tikoci/rosetta/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-07-20
+
 ### Added
 
 - **The resolved DB now reports whether it can be trusted to ground claims about the code querying it** (issue #94, B-0022 export-audit umbrella). `routeros_stats` gains a `provenance` block — resolved `db_path`, invocation `mode`, the `db_meta` stamps (`release_tag`/`source_commit`/`built_at`/`schema_version`), and a **grounding verdict** (`ok` / `schema_mismatch` / `internal_inconsistent` / `tag_behind` / `unstamped`) — so one call self-checks the DB against the checkout instead of shelling into sqlite (the TUI `stats` screen shows it too, via shared `getDbStats`). A new `make db-doctor` / `bun run db:doctor` prints the same verdict and exits non-zero when not `ok` (CI/pre-commit-ready); `make db-sync` / `bun run db:sync` fetches the latest CI release DB — the documented grounding source of truth — into the resolved path (atomic, safe while a server holds the file open). In a dev checkout, MCP startup now emits a loud but **non-fatal** banner when the served DB has drifted (e.g. a corpus whose `PRAGMA user_version` was bumped in place so its stamped provenance no longer describes its bytes); it never fetches, so a contributor's local build is never clobbered. The load-bearing new signal is `internal_inconsistent` (`db_meta.schema_version` ≠ pragma), which every prior check missed. Durable guidance lives in `.github/instructions/local-db-grounding.instructions.md`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tikoci/rosetta",
-  "version": "0.11.0-rc.0",
+  "version": "0.11.0",
   "description": "RouterOS documentation as SQLite FTS5 — RAG search + command glossary via MCP",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Manual pre-release step for the first **latest-channel** release since 0.10.0.

- `package.json`: `0.11.0-rc.0` → `0.11.0` (bare version ⇒ `latest` npm dist-tag + OCI `:latest`)
- `CHANGELOG.md`: `## [Unreleased]` promoted to `## [0.11.0] — 2026-07-20`, fresh `[Unreleased]` above it

No code changes. The content being released is exactly what already built and published green as `0.11.0-rc.104` from `d3459ed` (release run 29660653035).

Once merged, dispatch `Release` from `main` with **all inputs blank**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.11.0 is now officially released.
  * Added the dated 0.11.0 section to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->